### PR TITLE
Restrict frontend pages to authenticated users

### DIFF
--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { getClientAuth } from '@/lib/firebase';
+import styles from '@/styles/AuthGate.module.css';
+
+import type { Unsubscribe } from 'firebase/auth';
+
+type AuthState = 'loading' | 'authenticated' | 'unauthenticated';
+
+const PUBLIC_ROUTES = new Set(['/login', '/_error']);
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+const isPublicRoute = (pathname: string): boolean => {
+  return PUBLIC_ROUTES.has(pathname);
+};
+
+export default function AuthGate({ children }: AuthGateProps) {
+  const router = useRouter();
+  const [status, setStatus] = useState<AuthState>('loading');
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe: Unsubscribe | undefined;
+
+    (async () => {
+      try {
+        const auth = await getClientAuth();
+        const { onAuthStateChanged } = await import('firebase/auth');
+
+        unsubscribe = onAuthStateChanged(auth, (user) => {
+          if (!active) {
+            return;
+          }
+
+          if (user && !user.isAnonymous) {
+            setStatus('authenticated');
+          } else {
+            setStatus('unauthenticated');
+          }
+        });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        console.error('Falha ao inicializar a autenticação.', error);
+        setStatus('unauthenticated');
+      }
+    })();
+
+    return () => {
+      active = false;
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, []);
+
+  const pathname = router.pathname;
+  const routeIsPublic = useMemo(() => isPublicRoute(pathname), [pathname]);
+
+  useEffect(() => {
+    if (status === 'authenticated' && pathname === '/login') {
+      void router.replace('/');
+      return;
+    }
+
+    if (status === 'unauthenticated' && !routeIsPublic) {
+      void router.replace('/login');
+    }
+  }, [pathname, routeIsPublic, router, status]);
+
+  if (routeIsPublic) {
+    if (status === 'authenticated') {
+      return <div className={styles.loading}>Redirecionando...</div>;
+    }
+    return <>{children}</>;
+  }
+
+  if (status !== 'authenticated') {
+    return <div className={styles.loading}>Carregando sessão...</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import type { AppProps } from 'next/app';
+import AuthGate from '@/components/AuthGate';
 import '@/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthGate>
+      <Component {...pageProps} />
+    </AuthGate>
+  );
 }

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
             return;
           }
 
-          if (user) {
+          if (user && !user.isAnonymous) {
             const profile: AuthenticatedUserProfile = {
               uid: user.uid,
               displayName: user.displayName,
@@ -102,6 +102,12 @@ export default function LoginPage() {
     setError(null);
     try {
       const profile = await signInWithGoogle();
+      if (profile.isAnonymous) {
+        setUserInfo(null);
+        setStatus('signed-out');
+        setError(new Error('Não foi possível confirmar o login da conta Google. Tente novamente.'));
+        return;
+      }
       setUserInfo(toDisplayUserInfo(profile));
       setStatus('signed-in');
     } catch (err) {
@@ -135,10 +141,7 @@ export default function LoginPage() {
       <div className={styles.container}>
         <section className={styles.card}>
           <h3>Entrar com Google</h3>
-          <p>
-            Você pode continuar utilizando a autenticação anônima automática ou conectar sua conta Google para sincronizar seus
-            treinos com um usuário permanente.
-          </p>
+          <p>Faça login com sua conta Google para acessar o painel de treinos com segurança.</p>
           <button
             type="button"
             className={styles.googleButton}
@@ -172,9 +175,11 @@ export default function LoginPage() {
             </svg>
             <span>{isProcessing ? 'Processando...' : 'Entrar com Google'}</span>
           </button>
-          <button type="button" className={styles.signOutButton} onClick={handleSignOut} disabled={isProcessing}>
-            Sair da conta
-          </button>
+          {userInfo ? (
+            <button type="button" className={styles.signOutButton} onClick={handleSignOut} disabled={isProcessing}>
+              Sair da conta
+            </button>
+          ) : null}
           {error ? <p className={styles.errorMessage}>{error.message}</p> : null}
         </section>
 

--- a/frontend/src/styles/AuthGate.module.css
+++ b/frontend/src/styles/AuthGate.module.css
@@ -1,0 +1,10 @@
+.loading {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add a client-side auth gate to redirect unauthenticated visitors to the login page
- update the login flow and Firebase helper to require authenticated Google accounts
- style the authentication loading state to show friendly feedback during redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbfe1345088330ae40cd7d740a4502