### PR TITLE
feat: add collapsible sidebar navigation

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import styles from '@/styles/Layout.module.css';
 
 interface LayoutProps {
@@ -22,11 +22,40 @@ const navLinks: Array<{ href: string; label: string }> = [
 ];
 
 export default function Layout({ title, description, children }: LayoutProps) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
   return (
-    <div className={styles.appShell}>
-      <aside className={styles.sidebar}>
-        <h1 className={styles.brand}>Train API</h1>
-        <nav>
+    <div
+      className={
+        isSidebarOpen
+          ? styles.appShell
+          : `${styles.appShell} ${styles.appShellCollapsed}`
+      }
+    >
+      <aside
+        className={
+          isSidebarOpen
+            ? styles.sidebar
+            : `${styles.sidebar} ${styles.sidebarCollapsed}`
+        }
+      >
+        <button
+          type="button"
+          className={styles.toggleButton}
+          aria-expanded={isSidebarOpen}
+          aria-controls="sidebar-navigation"
+          onClick={() => setIsSidebarOpen((open) => !open)}
+        >
+          {isSidebarOpen ? 'Recolher menu' : 'Expandir menu'}
+        </button>
+        {isSidebarOpen ? (
+          <h1 className={styles.brand}>Train API</h1>
+        ) : (
+          <span className={styles.collapsedBrand} aria-hidden="true">
+            TA
+          </span>
+        )}
+        <nav id="sidebar-navigation" aria-hidden={!isSidebarOpen}>
           <ul>
             {navLinks.map((link) => (
               <li key={link.href}>

--- a/frontend/src/styles/Layout.module.css
+++ b/frontend/src/styles/Layout.module.css
@@ -2,6 +2,11 @@
   display: grid;
   grid-template-columns: 260px 1fr;
   min-height: 100vh;
+  transition: grid-template-columns 0.3s ease;
+}
+
+.appShellCollapsed {
+  grid-template-columns: 96px 1fr;
 }
 
 .sidebar {
@@ -11,11 +16,56 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  transition: padding 0.3s ease;
 }
 
 .brand {
   font-size: 1.5rem;
   font-weight: 600;
+}
+
+.collapsedBrand {
+  display: none;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+}
+
+.toggleButton {
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.75rem;
+  color: #f9fafb;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.5rem 0.75rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.toggleButton:hover,
+.toggleButton:focus {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.sidebarCollapsed {
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 0.75rem;
+}
+
+.sidebarCollapsed nav {
+  display: none;
+}
+
+.sidebarCollapsed .brand {
+  display: none;
+}
+
+.sidebarCollapsed .collapsedBrand {
+  display: block;
 }
 
 .sidebar ul {


### PR DESCRIPTION
## Summary
- add a toggle control to the sidebar layout so it can expand or collapse
- refine layout styling to support the collapsed state and expose a compact brand treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dea5fe81e48330b46dda5415e62b71