### PR TITLE
Revamp frontend styling and layout

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import styles from '@/styles/Layout.module.css';
 
@@ -21,27 +22,65 @@ const navLinks: Array<{ href: string; label: string }> = [
   { href: '/login', label: 'Login' }
 ];
 
+const isLinkActive = (pathname: string, href: string): boolean => {
+  if (href === '/') {
+    return pathname === '/';
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+};
+
 export default function Layout({ title, description, children }: LayoutProps) {
+  const { pathname } = useRouter();
+
   return (
     <div className={styles.appShell}>
       <aside className={styles.sidebar}>
-        <h1 className={styles.brand}>Train API</h1>
-        <nav>
-          <ul>
-            {navLinks.map((link) => (
-              <li key={link.href}>
-                <Link href={link.href}>{link.label}</Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <div className={styles.sidebarInner}>
+          <Link href="/" className={styles.brand} aria-label="Train API">
+            <span className={styles.brandIcon}>🏋️‍♂️</span>
+            <span className={styles.brandText}>Train API</span>
+          </Link>
+          <p className={styles.tagline}>Treinos inteligentes, progresso constante.</p>
+          <nav className={styles.nav} aria-label="Menu principal">
+            <ul>
+              {navLinks.map((link) => {
+                const active = isLinkActive(pathname, link.href);
+
+                return (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      aria-current={active ? 'page' : undefined}
+                      className={`${styles.navLink} ${active ? styles.navLinkActive : ''}`.trim()}
+                    >
+                      <span>{link.label}</span>
+                      <span className={styles.navIndicator} aria-hidden="true" />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </div>
+        <footer className={styles.sidebarFooter}>
+          <p>Atualizado diariamente com os dados mais recentes dos alunos.</p>
+        </footer>
       </aside>
       <main className={styles.contentArea}>
-        <header className={styles.pageHeader}>
-          <h2>{title}</h2>
-          {description ? <p>{description}</p> : null}
-        </header>
-        <section className={styles.pageBody}>{children}</section>
+        <div className={styles.contentWrapper}>
+          <header className={styles.pageHeader}>
+            <div>
+              <h2>{title}</h2>
+              {description ? <p>{description}</p> : null}
+            </div>
+            <div className={styles.pageAccent}>
+              <span className={styles.pageAccentGlow} aria-hidden="true" />
+              <span className={styles.pageAccentLabel}>Painel Train API</span>
+            </div>
+          </header>
+          <section className={styles.pageBody}>{children}</section>
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -1,7 +1,7 @@
 .pageSection {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 26px;
 }
 
 .sectionHeader {
@@ -13,76 +13,84 @@
 .filterRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 14px;
   align-items: center;
 }
 
 .filterRow label {
-  font-weight: 600;
-  color: #1f2933;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .selectInput {
   min-width: 240px;
-  padding: 8px 12px;
-  border: 1px solid #d2d6dc;
-  border-radius: 8px;
-  background-color: #fff;
-  color: #1f2933;
+  padding: 10px 14px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--color-heading);
   font-size: 1rem;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.selectInput:focus {
+  outline: none;
+  border-color: var(--color-primary-strong);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
 }
 
 .overviewCard {
-  background-color: #ffffff;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  padding: 20px;
-  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.06);
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 24px;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .overviewTitle {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #111827;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .overviewMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  color: #4b5563;
+  gap: 18px;
+  color: var(--color-text-muted);
   font-size: 0.95rem;
 }
 
 .progressGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 24px;
+  gap: 26px;
 }
 
 .progressCard {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  background-color: #fff;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  gap: 18px;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-strong);
+  box-shadow: 0 30px 65px -50px rgba(79, 70, 229, 0.45);
 }
 
 .progressHeader h3 {
-  font-size: 1.05rem;
+  font-size: 1.1rem;
   margin: 0;
-  color: #0f172a;
+  color: var(--color-heading);
 }
 
 .progressSubtitle {
   margin: 0;
-  color: #4b5563;
+  color: var(--color-text-muted);
   font-size: 0.95rem;
 }
 
@@ -98,35 +106,35 @@
 .chartSections {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 26px;
 }
 
 .metricChart {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .metricTitle {
   margin: 0;
   font-size: 1rem;
-  font-weight: 600;
-  color: #0f172a;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .metricDescription {
   margin: 0;
-  color: #4b5563;
-  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
 }
 
 .chartArea {
-  fill: #f8fafc;
-  stroke: #e2e8f0;
+  fill: rgba(148, 163, 184, 0.15);
+  stroke: rgba(226, 232, 240, 0.7);
 }
 
 .chartTick line {
-  stroke: rgba(148, 163, 184, 0.6);
+  stroke: rgba(148, 163, 184, 0.5);
   stroke-dasharray: 4;
 }
 
@@ -172,7 +180,7 @@
 
 .chartLegend {
   display: flex;
-  gap: 16px;
+  gap: 18px;
   color: #334155;
   font-size: 0.9rem;
 }
@@ -197,13 +205,17 @@
 .summaryTable {
   border-collapse: collapse;
   width: 100%;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
 }
 
 .summaryTable th,
 .summaryTable td {
-  padding: 8px 12px;
-  border-bottom: 1px solid #e2e8f0;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
   text-align: left;
 }
 
@@ -212,20 +224,21 @@
 }
 
 .emptyState {
-  background-color: #fff;
-  border-radius: 16px;
-  border: 1px dashed #cbd5f5;
-  padding: 32px;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  padding: 36px;
   text-align: center;
-  color: #4b5563;
+  color: var(--color-text-muted);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  box-shadow: 0 30px 60px -45px rgba(148, 163, 184, 0.45);
 }
 
 @media (max-width: 768px) {
   .progressCard {
-    padding: 16px;
+    padding: 20px;
   }
 
   .chartLegend {

--- a/frontend/src/styles/ExerciseClasses.module.css
+++ b/frontend/src/styles/ExerciseClasses.module.css
@@ -1,34 +1,37 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.32);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 25px 55px -40px rgba(239, 68, 68, 0.45);
 }
 
 .cardHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.85rem;
 }
 
 .cardHeader h3 {
-  font-size: 1.25rem;
+  font-size: 1.3rem;
+  color: var(--color-heading);
 }
 
 .cardHeader time {
   font-size: 0.9rem;
-  color: #6b7280;
+  color: var(--color-text-muted);
 }
 
 .cardFooter {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
   display: flex;
-  gap: 1.5rem;
-  color: #4b5563;
+  gap: 1.75rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
 }
 
 .cardFooter span strong {
-  color: #111827;
+  color: var(--color-heading);
 }

--- a/frontend/src/styles/Exercises.module.css
+++ b/frontend/src/styles/Exercises.module.css
@@ -1,9 +1,10 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.35);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 25px 55px -40px rgba(239, 68, 68, 0.45);
 }
 
 .cardHeader {
@@ -15,40 +16,52 @@
 }
 
 .cardHeader h3 {
-  font-size: 1.25rem;
+  font-size: 1.35rem;
+  color: var(--color-heading);
 }
 
 .cardHeader p {
-  color: #4b5563;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
 }
 
 .modality {
-  background: #059669;
-  color: #ffffff;
-  padding: 0.25rem 0.75rem;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(16, 185, 129, 0.25));
+  color: #047857;
+  padding: 0.35rem 0.9rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: 700;
+  border: 1px solid rgba(16, 185, 129, 0.28);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.2rem;
+  margin-top: 1.2rem;
 }
 
 .metrics div {
-  background: #f3f4f6;
-  border-radius: 10px;
-  padding: 0.75rem;
+  background: var(--color-primary-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .metrics dt {
-  font-weight: 600;
-  color: #111827;
+  font-weight: 700;
+  color: var(--color-primary-strong);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .metrics dd {
-  color: #4b5563;
+  color: var(--color-heading);
+  margin-top: 0.25rem;
+  font-weight: 600;
 }

--- a/frontend/src/styles/Home.module.css
+++ b/frontend/src/styles/Home.module.css
@@ -1,31 +1,85 @@
 .grid {
+  position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  padding: 1rem 0;
+}
+
+.grid::before {
+  content: '';
+  position: absolute;
+  inset: -25% -10%;
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.12), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(244, 114, 182, 0.12), transparent 60%);
+  filter: blur(40px);
+  opacity: 0.85;
+  pointer-events: none;
 }
 
 .card {
-  background: #ffffff;
-  padding: 1.75rem;
-  border-radius: 12px;
-  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  padding: 2rem 2.15rem;
+  border-radius: 22px;
+  background: var(--color-surface-strong);
+  color: var(--color-heading);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  box-shadow: 0 35px 55px -45px rgba(15, 23, 42, 0.9);
+  overflow: hidden;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -40% -40% 35% 35%;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(244, 114, 182, 0.1));
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  opacity: 0;
+  transition: opacity 220ms ease;
 }
 
 .card h3 {
-  font-size: 1.3rem;
-  color: #111827;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  position: relative;
+  z-index: 1;
 }
 
 .card p {
-  color: #4b5563;
+  position: relative;
+  z-index: 1;
+  color: var(--color-text-muted);
+  line-height: 1.5;
 }
 
 .card:hover,
 .card:focus {
-  transform: translateY(-4px);
-  box-shadow: 0 25px 50px rgba(30, 41, 59, 0.12);
+  transform: translateY(-8px);
+  box-shadow: 0 45px 75px -45px rgba(79, 70, 229, 0.45);
+}
+
+.card:hover::before,
+.card:focus::before,
+.card:hover::after,
+.card:focus::after {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.75rem;
+  }
 }

--- a/frontend/src/styles/Layout.module.css
+++ b/frontend/src/styles/Layout.module.css
@@ -1,62 +1,219 @@
 .appShell {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
   min-height: 100vh;
+  backdrop-filter: blur(0px);
 }
 
 .sidebar {
-  background: linear-gradient(135deg, #111827, #1f2937);
-  color: #f9fafb;
-  padding: 2rem 1.5rem;
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  justify-content: space-between;
+  padding: 2.75rem 2.25rem;
+  background: linear-gradient(185deg, rgba(15, 23, 42, 0.92), rgba(30, 64, 175, 0.88));
+  color: #f8fafc;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04), var(--color-shadow-soft);
+}
+
+.sidebarInner {
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
 }
 
 .brand {
-  font-size: 1.5rem;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  font-size: 1.55rem;
+  font-weight: 700;
+  color: inherit;
+  text-decoration: none;
+  letter-spacing: -0.015em;
 }
 
-.sidebar ul {
+.brandIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(79, 70, 229, 0.75));
+  box-shadow: 0 18px 35px -18px rgba(99, 102, 241, 0.75);
+}
+
+.brandText {
+  font-size: 1.45rem;
+}
+
+.tagline {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.nav ul {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.65rem;
 }
 
-.sidebar a {
-  color: #e5e7eb;
-  font-weight: 500;
+.navLink {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  color: rgba(226, 232, 240, 0.8);
+  font-weight: 600;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    background-color var(--transition-base), color var(--transition-base);
 }
 
-.sidebar a:hover,
-.sidebar a:focus {
+.navLink > span:first-child {
+  position: relative;
+  z-index: 1;
+}
+
+.navLink:hover,
+.navLink:focus {
   color: #ffffff;
+  transform: translateX(4px);
+}
+
+.navLink::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0));
+  opacity: 0;
+  transition: opacity var(--transition-base);
+  z-index: 0;
+}
+
+.navLink:hover::before,
+.navLink:focus::before {
+  opacity: 1;
+}
+
+.navIndicator {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.35);
+  transition: transform var(--transition-base), opacity var(--transition-base);
+  position: relative;
+  z-index: 1;
+}
+
+.navLinkActive {
+  color: #ffffff;
+  box-shadow: 0 20px 38px -24px rgba(148, 163, 184, 0.75);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(79, 70, 229, 0.45));
+}
+
+.navLinkActive .navIndicator {
+  background: #facc15;
+  transform: scale(1.4);
+  opacity: 1;
+}
+
+.sidebarFooter {
+  margin-top: 3rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+  line-height: 1.6;
 }
 
 .contentArea {
-  padding: 3rem 4rem;
-  background: #f5f7fb;
+  position: relative;
+  padding: 3rem;
+  background: radial-gradient(70% 70% at 0% 100%, rgba(99, 102, 241, 0.08), transparent 60%),
+    radial-gradient(75% 75% at 100% 0%, rgba(244, 114, 182, 0.1), transparent 65%);
+}
+
+.contentWrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--color-shadow-strong);
+  backdrop-filter: blur(22px);
 }
 
 .pageHeader {
-  margin-bottom: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
 }
 
 .pageHeader h2 {
   font-size: 2rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .pageHeader p {
-  color: #4b5563;
+  font-size: 1rem;
+}
+
+.pageAccent {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(99, 102, 241, 0.04));
+  border: 1px solid var(--color-border);
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  overflow: hidden;
+}
+
+.pageAccentGlow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 20% 50%, rgba(244, 114, 182, 0.25), transparent 55%);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.pageAccentLabel {
+  position: relative;
+  z-index: 1;
 }
 
 .pageBody {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
+}
+
+@media (max-width: 1200px) {
+  .contentArea {
+    padding: 2.5rem;
+  }
+
+  .contentWrapper {
+    padding: 2.25rem;
+  }
 }
 
 @media (max-width: 960px) {
@@ -65,13 +222,53 @@
   }
 
   .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 5;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
+    gap: 2rem;
+    padding: 1.5rem 1.75rem;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   }
 
-  .sidebar ul {
+  .sidebarInner {
+    flex-direction: row;
+    align-items: center;
+    gap: 1.75rem;
+  }
+
+  .tagline {
+    display: none;
+  }
+
+  .nav ul {
     flex-direction: row;
     flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .navLink {
+    padding: 0.65rem 0.9rem;
+    font-size: 0.95rem;
+  }
+
+  .sidebarFooter {
+    display: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .contentArea {
+    padding: 1.5rem;
+  }
+
+  .contentWrapper {
+    padding: 1.75rem;
+  }
+
+  .pageHeader h2 {
+    font-size: 1.65rem;
   }
 }

--- a/frontend/src/styles/Login.module.css
+++ b/frontend/src/styles/Login.module.css
@@ -1,56 +1,59 @@
 .container {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
   margin: 0 auto;
   width: 100%;
 }
 
 .card {
-  background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-  padding: 1.75rem;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
+  padding: 2.1rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.2rem;
+  border: 1px solid var(--color-border);
 }
 
 .card h3 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #0f172a;
+  font-size: 1.35rem;
+  color: var(--color-heading);
 }
 
 .card p {
   margin: 0;
-  line-height: 1.5;
-  color: #334155;
+  line-height: 1.6;
+  color: var(--color-text-muted);
 }
 
 .googleButton {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
   justify-content: center;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.4);
   border-radius: 999px;
-  padding: 0.75rem 1.5rem;
-  font-weight: 600;
-  color: #0f172a;
+  padding: 0.85rem 1.75rem;
+  font-weight: 700;
+  color: var(--color-heading);
   cursor: pointer;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 22px 45px -32px rgba(15, 23, 42, 0.4);
 }
 
 .googleButton:hover:not(:disabled) {
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 32px 65px -35px rgba(79, 70, 229, 0.45);
 }
 
 .googleButton:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+  box-shadow: none;
 }
 
 .googleIcon {
@@ -62,10 +65,10 @@
   align-self: flex-start;
   background: transparent;
   border: none;
-  color: #ef4444;
-  font-weight: 600;
+  color: var(--color-danger);
+  font-weight: 700;
   cursor: pointer;
-  padding: 0.25rem 0;
+  padding: 0.3rem 0;
 }
 
 .signOutButton:hover:not(:disabled) {
@@ -73,39 +76,42 @@
 }
 
 .errorMessage {
-  color: #dc2626;
-  font-size: 0.9rem;
+  color: var(--color-danger);
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .statusLabel {
-  font-weight: 600;
-  padding: 0.5rem 0.75rem;
+  font-weight: 700;
+  padding: 0.6rem 0.9rem;
   border-radius: 999px;
-  background: #f1f5f9;
-  color: #0f172a;
+  background: rgba(226, 232, 240, 0.7);
+  color: var(--color-heading);
   display: inline-flex;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .statusLabel[data-status='signed-in'] {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--color-success-soft);
+  color: var(--color-success);
 }
 
 .statusLabel[data-status='signed-out'] {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
 }
 
 .profile {
   display: flex;
-  gap: 1.25rem;
+  gap: 1.35rem;
   align-items: flex-start;
 }
 
 .avatar {
   border-radius: 50%;
   object-fit: cover;
+  box-shadow: 0 12px 35px -25px rgba(15, 23, 42, 0.45);
 }
 
 .profileDetails {
@@ -115,19 +121,19 @@
 }
 
 .profileDetails dt {
-  font-weight: 600;
-  color: #475569;
+  font-weight: 700;
+  color: var(--color-text-muted);
 }
 
 .profileDetails dd {
   margin: 0.25rem 0 0;
-  color: #0f172a;
-  word-break: break-all;
+  color: var(--color-heading);
+  word-break: break-word;
 }
 
 .emptyProfile {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-muted);
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/styles/MuscleGroups.module.css
+++ b/frontend/src/styles/MuscleGroups.module.css
@@ -1,52 +1,55 @@
 .formSection {
-  margin-bottom: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.3);
+  margin-bottom: 2.25rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--color-shadow-soft);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
+  backdrop-filter: blur(18px);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.35rem;
 }
 
 .fieldGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .fieldGroup label {
-  font-weight: 600;
-  color: #1f2937;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .fieldGroup input,
 .fieldGroup textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1.1rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  font-family: inherit;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: var(--color-heading);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .fieldGroup textarea {
   resize: vertical;
-  min-height: 120px;
+  min-height: 130px;
 }
 
 .fieldGroup input:focus,
 .fieldGroup textarea:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  border-color: var(--color-primary-strong);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
 }
 
 .actions {
@@ -55,55 +58,67 @@
 }
 
 .actions button {
-  background: #2563eb;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
   color: #ffffff;
   border: none;
   border-radius: 999px;
-  padding: 0.75rem 1.75rem;
-  font-weight: 600;
+  padding: 0.85rem 2.2rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 28px 55px -30px rgba(99, 102, 241, 0.65);
 }
 
 .actions button:disabled {
-  opacity: 0.7;
+  opacity: 0.65;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .actions button:not(:disabled):hover {
-  background: #1d4ed8;
+  transform: translateY(-2px);
+  box-shadow: 0 35px 65px -30px rgba(79, 70, 229, 0.65);
 }
 
 .actions button:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .success {
   margin: 0;
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .error {
   margin: 0;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .card {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.5rem;
-  background: #f9fafb;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  background: var(--color-surface-strong);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  box-shadow: 0 28px 60px -45px rgba(15, 23, 42, 0.55);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 38px 75px -45px rgba(79, 70, 229, 0.45);
 }
 
 .cardHeader {
@@ -115,18 +130,18 @@
 
 .cardHeader h3 {
   margin: 0;
-  font-size: 1.1rem;
-  color: #111827;
+  font-size: 1.2rem;
+  color: var(--color-heading);
 }
 
 .cardHeader time {
-  color: #6b7280;
-  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
 }
 
 .cardDescription {
   margin: 0;
-  color: #374151;
+  color: var(--color-text-muted);
 }
 
 .cardActions {
@@ -135,31 +150,34 @@
 }
 
 .deleteButton {
-  border: 1px solid #fca5a5;
-  background: #fef2f2;
-  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.38);
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.1), rgba(239, 68, 68, 0.18));
+  color: var(--color-danger);
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    background-color var(--transition-base);
 }
 
 .deleteButton:not(:disabled):hover {
-  background: #fee2e2;
+  transform: translateY(-2px);
+  box-shadow: 0 25px 55px -35px rgba(239, 68, 68, 0.45);
 }
 
 .deleteButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .deleteButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 @media (max-width: 640px) {
   .formSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/styles/ResourceList.module.css
+++ b/frontend/src/styles/ResourceList.module.css
@@ -1,27 +1,46 @@
 .list {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .listItem {
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  background: var(--color-surface-strong);
+  border-radius: 22px;
+  padding: 1.85rem 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 30px 65px -45px rgba(15, 23, 42, 0.6);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  overflow: hidden;
+}
+
+.listItem::before {
+  content: '';
+  position: absolute;
+  inset: -50% -10% 55% -10%;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(244, 114, 182, 0.12));
+  opacity: 0;
+  transition: opacity var(--transition-base);
 }
 
 .listItem:hover,
 .listItem:focus-within {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  transform: translateY(-6px);
+  box-shadow: 0 45px 85px -50px rgba(79, 70, 229, 0.55);
+}
+
+.listItem:hover::before,
+.listItem:focus-within::before {
+  opacity: 1;
 }
 
 .emptyState {
-  padding: 2rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  padding: 2.25rem;
+  background: var(--color-warning-soft);
+  border: 1px dashed rgba(245, 158, 11, 0.5);
+  border-radius: var(--radius-md);
+  color: rgba(180, 83, 9, 0.95);
   text-align: center;
+  font-weight: 600;
+  box-shadow: 0 25px 60px -40px rgba(180, 83, 9, 0.35);
 }

--- a/frontend/src/styles/Sessions.module.css
+++ b/frontend/src/styles/Sessions.module.css
@@ -1,45 +1,56 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.35);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 25px 55px -40px rgba(239, 68, 68, 0.45);
 }
 
 .cardHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.85rem;
 }
 
 .cardHeader span {
-  background: #7c3aed;
-  color: #ffffff;
-  padding: 0.25rem 0.75rem;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.18), rgba(99, 102, 241, 0.18));
+  color: #ede9fe;
+  padding: 0.35rem 0.9rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: 700;
+  border: 1px solid rgba(124, 58, 237, 0.35);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.1rem;
+  margin-top: 1.2rem;
 }
 
 .metrics div {
-  background: #eef2ff;
-  border-radius: 10px;
-  padding: 0.75rem;
+  background: linear-gradient(145deg, rgba(99, 102, 241, 0.15), rgba(124, 58, 237, 0.12));
+  border-radius: var(--radius-sm);
+  padding: 0.9rem;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .metrics dt {
-  font-weight: 600;
-  color: #312e81;
+  font-weight: 700;
+  color: var(--color-heading);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .metrics dd {
-  color: #4338ca;
+  color: var(--color-primary-strong);
+  margin-top: 0.2rem;
+  font-weight: 700;
 }

--- a/frontend/src/styles/WorkoutClassForm.module.css
+++ b/frontend/src/styles/WorkoutClassForm.module.css
@@ -1,50 +1,53 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .header h2 {
-  margin: 0 0 0.25rem;
+  margin: 0 0 0.35rem;
+  font-size: 1.65rem;
 }
 
 .header p {
   margin: 0;
-  color: #4b5563;
+  color: var(--color-text-muted);
 }
 
 .exerciseCount {
   align-self: flex-start;
-  background: #eef2ff;
-  color: #4338ca;
-  padding: 0.5rem 0.75rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(59, 130, 246, 0.1));
+  color: #1d4ed8;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
-  font-weight: 600;
-  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  border: 1px solid rgba(59, 130, 246, 0.25);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.9rem;
 }
 
 .prefillBanner {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1rem 1.25rem;
-  border-radius: 12px;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  color: #92400e;
+  gap: 0.9rem;
+  padding: 1.15rem 1.35rem;
+  border-radius: var(--radius-md);
+  background: var(--color-warning-soft);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  color: rgba(146, 64, 14, 0.95);
+  box-shadow: 0 28px 55px -45px rgba(245, 158, 11, 0.45);
 }
 
 .prefillBanner strong {
@@ -55,25 +58,26 @@
 .prefillActions {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
   font-size: 0.95rem;
 }
 
 .clearPrefillButton {
   align-self: flex-start;
-  background: #ffffff;
-  border: 1px solid #f59e0b;
-  color: #b45309;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  color: rgba(146, 64, 14, 0.95);
   border-radius: 999px;
-  padding: 0.45rem 1.25rem;
-  font-weight: 600;
+  padding: 0.55rem 1.4rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    background-color var(--transition-base);
 }
 
 .clearPrefillButton:hover {
-  background: #fef08a;
-  color: #92400e;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -30px rgba(245, 158, 11, 0.4);
 }
 
 @media (min-width: 640px) {
@@ -86,72 +90,75 @@
 
 .inlineFields {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.35rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .fieldGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.65rem;
 }
 
 .fieldGroup label {
-  font-weight: 600;
-  color: #1f2937;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .fieldGroup input,
 .fieldGroup select {
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1.1rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  background-color: #ffffff;
-  font-family: inherit;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--color-heading);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .fieldGroup input:focus,
 .fieldGroup select:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  border-color: var(--color-primary-strong);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
 }
 
 .fieldGroup select:disabled {
-  background-color: #f3f4f6;
+  background-color: rgba(226, 232, 240, 0.6);
   cursor: not-allowed;
-  color: #6b7280;
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .exerciseList {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .exerciseCard {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.5rem;
-  background: #f9fafb;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.85rem;
+  background: var(--color-surface-strong);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.4rem;
+  box-shadow: 0 32px 60px -45px rgba(15, 23, 42, 0.55);
 }
 
 .exerciseLegend {
   font-weight: 700;
-  font-size: 1rem;
-  color: #111827;
+  font-size: 1.05rem;
+  color: var(--color-heading);
   padding: 0 0.25rem;
+  letter-spacing: 0.02em;
 }
 
 .exerciseLibraryRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.1rem;
   align-items: flex-end;
   justify-content: space-between;
 }
@@ -159,7 +166,7 @@
 .exerciseLibraryActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.6rem;
   align-items: center;
 }
 
@@ -170,7 +177,7 @@
 
 .exerciseHeader {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.35rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
@@ -180,22 +187,23 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .setRow {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
-  border: 1px dashed #c7d2fe;
-  border-radius: 10px;
-  background: #eef2ff;
+  gap: 1.1rem;
+  padding: 1.1rem;
+  border: 1px dashed rgba(99, 102, 241, 0.28);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-soft);
 }
 
 .setLabel {
-  font-weight: 600;
-  color: #3730a3;
+  font-weight: 700;
+  color: var(--color-primary-strong);
+  letter-spacing: 0.04em;
 }
 
 .setActions {
@@ -206,122 +214,125 @@
 .exerciseActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.85rem;
   justify-content: space-between;
 }
 
 .primaryButton {
   align-self: flex-end;
-  background: #2563eb;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
   color: #ffffff;
   border: none;
   border-radius: 999px;
-  padding: 0.75rem 1.75rem;
-  font-weight: 600;
+  padding: 0.85rem 2.25rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 28px 55px -30px rgba(99, 102, 241, 0.65);
 }
 
 .primaryButton:disabled {
-  opacity: 0.7;
+  opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .primaryButton:not(:disabled):hover {
-  background: #1d4ed8;
-}
-
-.primaryButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(-2px);
+  box-shadow: 0 35px 65px -30px rgba(79, 70, 229, 0.65);
 }
 
 .secondaryButton {
-  background: #e0e7ff;
-  color: #312e81;
+  background: rgba(224, 231, 255, 0.75);
+  color: var(--color-primary-strong);
   border: none;
   border-radius: 999px;
-  padding: 0.65rem 1.5rem;
-  font-weight: 600;
+  padding: 0.75rem 1.9rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .secondaryButton:hover {
-  background: #c7d2fe;
+  transform: translateY(-1px);
+  box-shadow: 0 20px 45px -32px rgba(99, 102, 241, 0.4);
 }
 
 .saveExerciseButton {
-  background: #ecfccb;
-  color: #3f6212;
-  border: 1px solid #bbf7d0;
+  background: linear-gradient(135deg, rgba(163, 230, 53, 0.35), rgba(132, 204, 22, 0.3));
+  color: #365314;
+  border: 1px solid rgba(132, 204, 22, 0.35);
   border-radius: 999px;
-  padding: 0.55rem 1.5rem;
-  font-weight: 600;
+  padding: 0.65rem 1.75rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .saveExerciseButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .saveExerciseButton:not(:disabled):hover {
-  background: #d9f99d;
-  border-color: #bef264;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -32px rgba(132, 204, 22, 0.4);
 }
 
 .editorLinkButton {
-  background: #eef2ff;
-  color: #312e81;
-  border: 1px solid #c7d2fe;
+  background: rgba(224, 231, 255, 0.75);
+  color: var(--color-primary-strong);
+  border: 1px solid rgba(99, 102, 241, 0.28);
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  font-weight: 600;
+  padding: 0.55rem 1.5rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .editorLinkButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorLinkButton:not(:disabled):hover {
-  background: #c7d2fe;
-  border-color: #a5b4fc;
+  transform: translateY(-1px);
+  box-shadow: 0 20px 45px -32px rgba(99, 102, 241, 0.35);
 }
 
 .dangerButton {
-  background: #fef2f2;
-  color: #b91c1c;
-  border: 1px solid #fecaca;
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.12), rgba(239, 68, 68, 0.18));
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: 999px;
-  padding: 0.5rem 1.2rem;
-  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .dangerButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .dangerButton:not(:disabled):hover {
-  background: #fee2e2;
-  border-color: #fca5a5;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -32px rgba(239, 68, 68, 0.4);
 }
 
 .removeButton {
   background: transparent;
   border: none;
-  color: #b91c1c;
-  font-weight: 600;
+  color: var(--color-danger);
+  font-weight: 700;
   cursor: pointer;
-  padding: 0.5rem 0.75rem;
-  border-radius: 6px;
-  transition: background 0.2s ease;
+  padding: 0.55rem 0.9rem;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-base);
 }
 
 .removeButton:disabled {
@@ -330,47 +341,50 @@
 }
 
 .removeButton:not(:disabled):hover {
-  background: rgba(248, 113, 113, 0.15);
+  background: rgba(239, 68, 68, 0.12);
 }
 
 .formActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.85rem;
   justify-content: flex-end;
   align-items: center;
 }
 
 .inlineError {
   margin: 0;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .inlineSuccess {
   margin: 0;
-  background: #dcfce7;
-  color: #047857;
-  border: 1px solid #bbf7d0;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .supportMessage {
   margin: 0;
-  background: #eff6ff;
+  background: rgba(191, 219, 254, 0.6);
   color: #1d4ed8;
-  border: 1px solid #bfdbfe;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  border: 1px solid rgba(96, 165, 250, 0.5);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .supportMessage a {
   color: #1d4ed8;
-  font-weight: 600;
+  font-weight: 700;
   text-decoration: none;
 }
 
@@ -381,11 +395,11 @@
 .exerciseEditor {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.5rem;
-  border: 1px solid #dbeafe;
-  border-radius: 12px;
-  background: #eff6ff;
+  gap: 1.35rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(191, 219, 254, 0.65);
+  border-radius: var(--radius-md);
+  background: rgba(224, 242, 254, 0.55);
 }
 
 .exerciseEditorHeader {
@@ -398,31 +412,32 @@
 
 .exerciseEditorHeader h3 {
   margin: 0;
+  color: var(--color-heading);
 }
 
 .exerciseEditorHeader p {
   margin: 0.25rem 0 0;
-  color: #1d4ed8;
+  color: #0ea5e9;
 }
 
 .editorCloseButton {
   background: transparent;
   border: none;
-  color: #1f2937;
-  font-weight: 600;
+  color: var(--color-heading);
+  font-weight: 700;
   cursor: pointer;
-  padding: 0.35rem 0.75rem;
-  border-radius: 8px;
-  transition: background 0.2s ease;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-base);
 }
 
 .editorCloseButton:hover {
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(14, 165, 233, 0.12);
 }
 
 .exerciseEditorGrid {
   display: grid;
-  gap: 1rem;
+  gap: 1.15rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -437,53 +452,54 @@
 .exerciseEditorPrimaryActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.85rem;
   align-items: center;
   justify-content: flex-end;
 }
 
 .editorPrimaryButton {
-  background: #2563eb;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
   color: #ffffff;
   border: none;
   border-radius: 999px;
-  padding: 0.65rem 1.6rem;
-  font-weight: 600;
+  padding: 0.75rem 2rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 28px 55px -30px rgba(99, 102, 241, 0.65);
 }
 
 .editorPrimaryButton:disabled {
-  opacity: 0.7;
+  opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorPrimaryButton:not(:disabled):hover {
-  background: #1d4ed8;
-}
-
-.editorPrimaryButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(-2px);
+  box-shadow: 0 35px 65px -30px rgba(79, 70, 229, 0.65);
 }
 
 .editorSecondaryButton {
-  background: #e0e7ff;
-  color: #312e81;
+  background: rgba(224, 231, 255, 0.75);
+  color: var(--color-primary-strong);
   border: none;
   border-radius: 999px;
-  padding: 0.6rem 1.4rem;
-  font-weight: 600;
+  padding: 0.7rem 1.8rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .editorSecondaryButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorSecondaryButton:not(:disabled):hover {
-  background: #c7d2fe;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -32px rgba(99, 102, 241, 0.4);
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/styles/WorkoutClassList.module.css
+++ b/frontend/src/styles/WorkoutClassList.module.css
@@ -1,13 +1,13 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .cardHeader {
@@ -19,7 +19,8 @@
 
 .cardHeader h3 {
   margin: 0 0 0.5rem;
-  font-size: 1.4rem;
+  font-size: 1.45rem;
+  color: var(--color-heading);
 }
 
 .metaList {
@@ -28,8 +29,8 @@
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  color: #4b5563;
+  gap: 0.85rem;
+  color: var(--color-text-muted);
   font-size: 0.95rem;
 }
 
@@ -37,35 +38,37 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.5rem;
-  color: #1f2937;
+  gap: 0.6rem;
+  color: var(--color-heading);
+  font-weight: 600;
 }
 
 .metrics span {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .notes {
   margin: 0;
-  padding: 1rem;
-  border-radius: 10px;
-  background: #ecfdf5;
-  color: #047857;
+  padding: 1.1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
 }
 
 .cardActions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.85rem;
   flex-wrap: wrap;
 }
 
 .sessionTabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .sessionTab {
@@ -73,28 +76,31 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.25rem;
-  padding: 0.65rem 1.1rem;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
-  color: #1e293b;
-  font-weight: 600;
+  padding: 0.75rem 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-heading);
+  font-weight: 700;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base);
 }
 
 .sessionTab:hover,
 .sessionTab:focus-visible {
-  background: #e0f2fe;
+  background: rgba(224, 231, 255, 0.75);
   outline: none;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 45px -32px rgba(99, 102, 241, 0.4);
 }
 
 .activeSessionTab {
-  background: #1d4ed8;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
   color: #ffffff;
-  border-color: #1d4ed8;
-  box-shadow: 0 12px 30px rgba(29, 78, 216, 0.22);
+  border-color: transparent;
+  box-shadow: 0 28px 55px -35px rgba(79, 70, 229, 0.6);
 }
 
 .sessionTabLabel {
@@ -110,85 +116,85 @@
 .sessionSummary {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .sessionInfo {
-  color: #1f2937;
-  font-weight: 600;
+  color: var(--color-heading);
+  font-weight: 700;
 }
 
 .emptyMessage {
-  padding: 1.25rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  padding: 1.35rem;
+  background: var(--color-warning-soft);
+  border: 1px dashed rgba(245, 158, 11, 0.45);
+  border-radius: var(--radius-sm);
+  color: rgba(146, 64, 14, 0.95);
+  font-weight: 600;
 }
 
 .duplicateButton {
-  border: 1px solid #2563eb;
-  background: #eff6ff;
+  border: 1px solid rgba(37, 99, 235, 0.5);
+  background: rgba(37, 99, 235, 0.12);
   color: #1d4ed8;
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  font-weight: 600;
+  padding: 0.6rem 1.4rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .duplicateButton:not(:disabled):hover {
-  background: #dbeafe;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -30px rgba(37, 99, 235, 0.45);
 }
 
 .duplicateButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .duplicateButton:disabled,
 .deleteButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.duplicateButton:disabled:active,
-.deleteButton:disabled:active {
-  transform: none;
+  box-shadow: none;
 }
 
 .deleteButton {
-  border: 1px solid #dc2626;
-  background: #fef2f2;
-  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--color-danger);
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  font-weight: 600;
+  padding: 0.6rem 1.4rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
 .deleteButton:not(:disabled):hover {
-  background: #fee2e2;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px -32px rgba(239, 68, 68, 0.4);
 }
 
 .deleteButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .exerciseGrid {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.35rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .exerciseCard {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.35rem;
+  background: var(--color-surface-strong);
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  box-shadow: 0 28px 55px -45px rgba(15, 23, 42, 0.5);
 }
 
 .exerciseHeader {
@@ -196,91 +202,4 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
-}
-
-.exerciseHeader h4 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.exerciseHeader span {
-  color: #4b5563;
-  font-size: 0.9rem;
-}
-
-.seriesCount {
-  background: #dbeafe;
-  color: #1d4ed8;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.exerciseNotes {
-  margin: 0;
-  color: #374151;
-  font-size: 0.95rem;
-}
-
-.setList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.setItem {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
-}
-
-.setOrder {
-  font-weight: 600;
-  color: #1f2937;
-}
-
-.setMetric {
-  color: #2563eb;
-  font-weight: 600;
-}
-
-@media (max-width: 640px) {
-  .metrics {
-    align-items: flex-start;
-  }
-
-  .metrics span {
-    font-size: 0.95rem;
-  }
-
-  .cardHeader {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .exerciseHeader {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .cardActions {
-    justify-content: flex-start;
-  }
-
-  .sessionTabs {
-    gap: 0.5rem;
-  }
-
-  .sessionTab {
-    width: 100%;
-  }
 }

--- a/frontend/src/styles/WorkoutHistoryByDate.module.css
+++ b/frontend/src/styles/WorkoutHistoryByDate.module.css
@@ -6,9 +6,11 @@
 
 .empty {
   padding: 2rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  background: var(--color-warning-soft);
+  border: 1px dashed rgba(245, 158, 11, 0.45);
+  border-radius: var(--radius-md);
+  color: rgba(146, 64, 14, 0.95);
   text-align: center;
+  font-weight: 600;
+  box-shadow: 0 28px 60px -45px rgba(245, 158, 11, 0.4);
 }

--- a/frontend/src/styles/Workouts.module.css
+++ b/frontend/src/styles/Workouts.module.css
@@ -1,146 +1,150 @@
 .modeSection {
-  margin-bottom: 2rem;
-  padding: 1.5rem 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #f8fafc;
+  margin-bottom: 2.25rem;
+  padding: 1.85rem 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.35rem;
+  box-shadow: var(--color-shadow-soft);
+  backdrop-filter: blur(18px);
 }
 
 .modeHeader h3 {
   margin: 0 0 0.5rem;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #0f172a;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .modeDescription {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-muted);
   line-height: 1.5;
 }
 
 .modeToggle {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.9rem;
 }
 
 .modeButton {
   flex: 1 1 240px;
-  padding: 0.85rem 1.25rem;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
-  color: #1e293b;
-  font-weight: 600;
+  padding: 1rem 1.3rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--color-heading);
+  font-weight: 700;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.35);
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 20px 45px -32px rgba(79, 70, 229, 0.4);
 }
 
 .modeButton:hover {
-  border-color: #818cf8;
-  box-shadow: 0 18px 35px -20px rgba(79, 70, 229, 0.35);
-  transform: translateY(-1px);
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 28px 55px -35px rgba(79, 70, 229, 0.45);
 }
 
 .modeButtonActive {
-  border-color: #4f46e5;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(79, 70, 229, 0.05));
-  color: #312e81;
+  border-color: var(--color-primary-strong);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.22), rgba(99, 102, 241, 0.12));
+  color: var(--color-primary-strong);
 }
 
 .formSection {
-  margin-bottom: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.3);
+  margin-bottom: 2.25rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: var(--color-shadow-soft);
 }
 
 .historySection,
 .historyPreview {
-  margin-top: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.2);
+  margin-top: 2.25rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: 0 32px 60px -45px rgba(15, 23, 42, 0.55);
 }
 
 .historyHeader {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.6rem;
 }
 
 .historyHeader h3 {
   margin: 0 0 0.5rem;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: #0f172a;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .historyHeader p {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-muted);
   line-height: 1.6;
 }
 
 .existingSelector {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
   margin-bottom: 1.5rem;
 }
 
 .selectLabel {
-  font-weight: 600;
-  color: #1e293b;
+  font-weight: 700;
+  color: var(--color-heading);
 }
 
 .selectRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.9rem;
   align-items: center;
 }
 
 .selectControl {
   flex: 1 1 260px;
   min-width: 220px;
-  padding: 0.75rem 1rem;
-  border: 1px solid #cbd5f5;
-  border-radius: 12px;
-  background: #f8fafc;
-  color: #1f2937;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-heading);
   font-size: 0.95rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .selectControl:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  border-color: var(--color-primary-strong);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
 }
 
 .selectAction {
-  padding: 0.75rem 1.5rem;
-  border-radius: 12px;
+  padding: 0.85rem 1.85rem;
+  border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
   color: #ffffff;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 12px 25px -18px rgba(79, 70, 229, 0.7);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 28px 55px -30px rgba(99, 102, 241, 0.65);
 }
 
 .selectAction:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px -18px rgba(79, 70, 229, 0.75);
+  transform: translateY(-2px);
+  box-shadow: 0 35px 65px -30px rgba(79, 70, 229, 0.65);
 }
 
 .selectAction:disabled {
@@ -151,25 +155,27 @@
 
 .success {
   margin-top: 1rem;
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
-  padding: 1rem 1.5rem;
-  border-radius: 10px;
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 .error {
   margin-top: 1rem;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-  padding: 1rem 1.5rem;
-  border-radius: 10px;
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
 }
 
 @media (max-width: 640px) {
   .modeSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .modeToggle {
@@ -177,12 +183,12 @@
   }
 
   .formSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .historySection,
   .historyPreview {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .selectRow {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,8 +1,32 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f5f5f5;
-  color: #1f1f1f;
+  --color-background: #eef2ff;
+  --color-background-muted: #e0f2fe;
+  --color-surface: rgba(255, 255, 255, 0.82);
+  --color-surface-strong: #ffffff;
+  --color-surface-muted: rgba(255, 255, 255, 0.65);
+  --color-border: rgba(99, 102, 241, 0.18);
+  --color-border-strong: rgba(99, 102, 241, 0.35);
+  --color-shadow-soft: 0 20px 55px -35px rgba(15, 23, 42, 0.6);
+  --color-shadow-strong: 0 35px 85px -40px rgba(79, 70, 229, 0.55);
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-heading: #111827;
+  --color-primary: #6366f1;
+  --color-primary-strong: #4f46e5;
+  --color-primary-soft: rgba(99, 102, 241, 0.12);
+  --color-accent: #f472b6;
+  --color-success: #16a34a;
+  --color-success-soft: rgba(22, 163, 74, 0.12);
+  --color-danger: #ef4444;
+  --color-danger-soft: rgba(239, 68, 68, 0.12);
+  --color-warning: #f59e0b;
+  --color-warning-soft: rgba(245, 158, 11, 0.16);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition-base: 200ms ease;
 }
 
 a {
@@ -17,9 +41,85 @@ a {
 }
 
 body {
-  background-color: #f5f5f5;
+  min-height: 100vh;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(99, 102, 241, 0.12) 0%, rgba(99, 102, 241, 0) 60%)
+      no-repeat,
+    radial-gradient(140% 140% at 100% 0%, rgba(244, 114, 182, 0.12) 0%, rgba(244, 114, 182, 0) 65%)
+      no-repeat,
+    linear-gradient(135deg, var(--color-background), var(--color-background-muted));
+  color: var(--color-text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 main {
   min-height: 100vh;
+}
+
+p {
+  color: var(--color-text-muted);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+  color: var(--color-heading);
+  letter-spacing: -0.01em;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+button {
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    background-color var(--transition-base), color var(--transition-base);
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+::selection {
+  background: rgba(99, 102, 241, 0.25);
+  color: var(--color-heading);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(99, 102, 241, 0.6);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(79, 70, 229, 0.8);
+}
+
+table {
+  border-collapse: collapse;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- refresh the layout shell with an accent sidebar, highlighted navigation, and glassmorphism content surface
- redesign global styles and resource cards to establish a cohesive color palette and elevated UI feel across every page
- polish module-specific components (workouts, login, dashboards, etc.) with gradients, improved spacing, and consistent feedback chips

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dee4f420208330ae9cb18e295fd908