### PR TITLE
style: modernize layout shell aesthetic

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import styles from '@/styles/Layout.module.css';
 
@@ -22,26 +23,44 @@ const navLinks: Array<{ href: string; label: string }> = [
 ];
 
 export default function Layout({ title, description, children }: LayoutProps) {
+  const pathname = usePathname();
+
   return (
     <div className={styles.appShell}>
       <aside className={styles.sidebar}>
-        <h1 className={styles.brand}>Train API</h1>
-        <nav>
-          <ul>
-            {navLinks.map((link) => (
-              <li key={link.href}>
-                <Link href={link.href}>{link.label}</Link>
-              </li>
-            ))}
+        <div className={styles.brandBlock}>
+          <h1 className={styles.brand}>Train API</h1>
+          <p className={styles.brandTagline}>Planeje, acompanhe e evolua seus treinos com clareza.</p>
+        </div>
+        <nav aria-label="Navegação principal" className={styles.nav}>
+          <ul className={styles.navList}>
+            {navLinks.map((link) => {
+              const isRoot = link.href === '/';
+              const isActive = isRoot ? pathname === '/' : pathname?.startsWith(link.href);
+              const linkClassName = isActive
+                ? `${styles.navLink} ${styles.navLinkActive}`
+                : styles.navLink;
+
+              return (
+                <li key={link.href}>
+                  <Link href={link.href} className={linkClassName}>
+                    <span className={styles.navLinkIndicator} aria-hidden="true" />
+                    <span className={styles.navLinkLabel}>{link.label}</span>
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </nav>
       </aside>
       <main className={styles.contentArea}>
-        <header className={styles.pageHeader}>
-          <h2>{title}</h2>
-          {description ? <p>{description}</p> : null}
-        </header>
-        <section className={styles.pageBody}>{children}</section>
+        <div className={styles.contentInner}>
+          <header className={styles.pageHeader}>
+            <h2 className={styles.pageTitle}>{title}</h2>
+            {description ? <p className={styles.pageDescription}>{description}</p> : null}
+          </header>
+          <section className={styles.pageBody}>{children}</section>
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -19,25 +19,33 @@
 
 .filterRow label {
   font-weight: 600;
-  color: #1f2933;
+  color: var(--text-primary);
 }
 
 .selectInput {
   min-width: 240px;
   padding: 8px 12px;
-  border: 1px solid #d2d6dc;
-  border-radius: 8px;
-  background-color: #fff;
-  color: #1f2933;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background-color: var(--surface-card-strong);
+  color: var(--text-primary);
   font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.selectInput:focus {
+  outline: none;
+  border-color: var(--accent-500);
+  background: var(--surface-muted);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
 }
 
 .overviewCard {
-  background-color: #ffffff;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
+  background-color: var(--surface-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-soft);
   padding: 20px;
-  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--shadow-xs);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -46,14 +54,14 @@
 .overviewTitle {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #111827;
+  color: var(--text-primary);
 }
 
 .overviewMeta {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
-  color: #4b5563;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -67,22 +75,22 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 20px;
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  background-color: #fff;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  padding: 22px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-soft);
+  background-color: var(--surface-card);
+  box-shadow: var(--shadow-xs);
 }
 
 .progressHeader h3 {
   font-size: 1.05rem;
   margin: 0;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .progressSubtitle {
   margin: 0;
-  color: #4b5563;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -111,12 +119,12 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .metricDescription {
   margin: 0;
-  color: #4b5563;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
@@ -173,7 +181,7 @@
 .chartLegend {
   display: flex;
   gap: 16px;
-  color: #334155;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
@@ -212,15 +220,16 @@
 }
 
 .emptyState {
-  background-color: #fff;
-  border-radius: 16px;
-  border: 1px dashed #cbd5f5;
+  background-color: var(--surface-card);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(129, 140, 248, 0.4);
   padding: 32px;
   text-align: center;
-  color: #4b5563;
+  color: var(--text-secondary);
   display: flex;
   flex-direction: column;
   gap: 8px;
+  box-shadow: var(--shadow-xs);
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/styles/ExerciseClasses.module.css
+++ b/frontend/src/styles/ExerciseClasses.module.css
@@ -1,34 +1,53 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .cardHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 0.75rem;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .cardHeader h3 {
   font-size: 1.25rem;
+  color: var(--text-primary);
 }
 
 .cardHeader time {
   font-size: 0.9rem;
-  color: #6b7280;
+  color: var(--text-muted);
+  background: rgba(148, 163, 184, 0.16);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-pill);
 }
 
 .cardFooter {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
   display: flex;
-  gap: 1.5rem;
-  color: #4b5563;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+}
+
+.cardFooter span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 500;
 }
 
 .cardFooter span strong {
-  color: #111827;
+  color: var(--text-primary);
 }

--- a/frontend/src/styles/Exercises.module.css
+++ b/frontend/src/styles/Exercises.module.css
@@ -1,9 +1,10 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .cardHeader {
@@ -11,44 +12,52 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 1.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .cardHeader h3 {
   font-size: 1.25rem;
+  color: var(--text-primary);
 }
 
 .cardHeader p {
-  color: #4b5563;
+  color: var(--text-secondary);
 }
 
 .modality {
-  background: #059669;
-  color: #ffffff;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(59, 130, 246, 0.08));
+  color: var(--accent-600);
+  padding: 0.35rem 0.9rem;
+  border-radius: var(--radius-pill);
   font-size: 0.85rem;
   font-weight: 600;
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  box-shadow: 0 6px 18px -12px rgba(99, 102, 241, 0.45);
 }
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.1rem;
+  margin-top: 1.25rem;
 }
 
 .metrics div {
-  background: #f3f4f6;
-  border-radius: 10px;
-  padding: 0.75rem;
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .metrics dt {
   font-weight: 600;
-  color: #111827;
+  color: var(--text-primary);
 }
 
 .metrics dd {
-  color: #4b5563;
+  color: var(--text-secondary);
+  margin-top: 0.35rem;
 }

--- a/frontend/src/styles/Home.module.css
+++ b/frontend/src/styles/Home.module.css
@@ -1,31 +1,52 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
 }
 
 .card {
-  background: #ffffff;
-  padding: 1.75rem;
-  border-radius: 12px;
-  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  background: var(--surface-card);
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  overflow: hidden;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -45% -20% auto;
+  height: 75%;
+  background: radial-gradient(80% 80% at 20% 25%, rgba(99, 102, 241, 0.16) 0%, transparent 70%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
 }
 
 .card h3 {
-  font-size: 1.3rem;
-  color: #111827;
+  font-size: 1.35rem;
+  letter-spacing: -0.015em;
+  color: var(--text-primary);
 }
 
 .card p {
-  color: #4b5563;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 .card:hover,
 .card:focus {
-  transform: translateY(-4px);
-  box-shadow: 0 25px 50px rgba(30, 41, 59, 0.12);
+  transform: translateY(-8px) scale(1.01);
+  box-shadow: var(--shadow-md);
+}
+
+.card:hover::before,
+.card:focus::before {
+  opacity: 1;
 }

--- a/frontend/src/styles/Layout.module.css
+++ b/frontend/src/styles/Layout.module.css
@@ -1,77 +1,339 @@
 .appShell {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 3.5rem);
   min-height: 100vh;
+  padding: clamp(1.75rem, 4vw, 3rem);
+  width: min(1320px, 100%);
+  margin: 0 auto;
+  position: relative;
+  isolation: isolate;
+  align-items: start;
 }
 
 .sidebar {
-  background: linear-gradient(135deg, #111827, #1f2937);
-  color: #f9fafb;
-  padding: 2rem 1.5rem;
+  position: sticky;
+  top: clamp(1.5rem, 3vh, 2.75rem);
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 2.75rem;
+  padding: 2.75rem 2.5rem;
+  border-radius: var(--radius-xl);
+  background: var(--surface-sidebar);
+  color: var(--text-contrast);
+  border: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(var(--blur-strong));
+  -webkit-backdrop-filter: blur(var(--blur-strong));
+  overflow: hidden;
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: -45% -35% auto;
+  height: 80%;
+  background: radial-gradient(60% 60% at 18% 24%, rgba(129, 140, 248, 0.5) 0%, transparent 70%);
+  opacity: 0.7;
+  pointer-events: none;
+  filter: blur(0.5px);
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  inset: auto -30% -40%;
+  height: 65%;
+  background: radial-gradient(55% 55% at 70% 80%, rgba(56, 189, 248, 0.35) 0%, transparent 75%);
+  pointer-events: none;
+}
+
+.brandBlock {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .brand {
-  font-size: 1.5rem;
-  font-weight: 600;
+  font-size: clamp(2rem, 2.6vw, 2.35rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
 }
 
-.sidebar ul {
+.brandTagline {
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-width: 26ch;
+}
+
+.nav {
+  position: relative;
+  z-index: 1;
+}
+
+.navList {
   list-style: none;
   display: flex;
   flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  margin: 0;
+  border-radius: calc(var(--radius-md) + 8px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.32) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+}
+
+.navLink {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   gap: 1rem;
+  width: 100%;
+  padding: 0.95rem 1.1rem;
+  border-radius: var(--radius-md);
+  color: rgba(226, 232, 240, 0.8);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: linear-gradient(130deg, rgba(15, 23, 42, 0.62) 0%, rgba(15, 23, 42, 0.46) 100%);
+  border: 1px solid transparent;
+  transition: transform 0.4s ease, color 0.3s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+  isolation: isolate;
+  outline: none;
+  overflow: hidden;
 }
 
-.sidebar a {
-  color: #e5e7eb;
-  font-weight: 500;
+.navLink::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.28), rgba(56, 189, 248, 0.18));
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  z-index: 0;
 }
 
-.sidebar a:hover,
-.sidebar a:focus {
-  color: #ffffff;
+.navLink:hover,
+.navLink:focus-visible {
+  color: var(--text-contrast);
+  transform: translateX(6px);
+  border-color: rgba(129, 140, 248, 0.42);
+  box-shadow: 0 22px 46px -28px rgba(129, 140, 248, 0.6);
+}
+
+.navLink:hover::after,
+.navLink:focus-visible::after {
+  opacity: 1;
+}
+
+.navLink:focus-visible {
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.5);
+}
+
+.navLinkIndicator {
+  width: 0.45rem;
+  height: 1.6rem;
+  border-radius: var(--radius-pill);
+  background: rgba(148, 163, 184, 0.4);
+  transition: background 0.3s ease, transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.navLinkLabel {
+  position: relative;
+  z-index: 1;
+}
+
+.navLink:hover .navLinkIndicator,
+.navLink:focus-visible .navLinkIndicator {
+  background: var(--accent-300);
+  transform: translateX(1px) scaleX(1.05);
+  opacity: 1;
+}
+
+.navLinkActive {
+  color: var(--text-contrast);
+  transform: translateX(10px);
+  border-color: rgba(129, 140, 248, 0.58);
+  box-shadow: 0 28px 60px -30px rgba(99, 102, 241, 0.7);
+}
+
+.navLinkActive::after {
+  opacity: 1;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.45), rgba(56, 189, 248, 0.25));
+}
+
+.navLinkActive .navLinkIndicator {
+  background: var(--accent-400);
+  transform: translateX(2px) scaleX(1.12);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15), 0 8px 20px -10px rgba(99, 102, 241, 0.9);
 }
 
 .contentArea {
-  padding: 3rem 4rem;
-  background: #f5f7fb;
+  position: relative;
+  padding: clamp(2.5rem, 5vw, 3.75rem);
+  background: var(--surface-content);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.contentArea::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      140% 120% at 55% -10%,
+      rgba(148, 163, 184, 0.2) 0%,
+      rgba(248, 250, 252, 0) 60%
+    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.65) 0%, rgba(255, 255, 255, 0) 55%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.contentInner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2.75rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .pageHeader {
-  margin-bottom: 2rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow-xs);
+  padding: clamp(1.75rem, 3vw, 2.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  overflow: hidden;
 }
 
-.pageHeader h2 {
+.pageHeader::after {
+  content: '';
+  position: absolute;
+  inset: -40% -20% auto;
+  height: 80%;
+  background: radial-gradient(70% 70% at 18% 25%, rgba(129, 140, 248, 0.25) 0%, transparent 75%);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+.pageTitle {
   font-size: 2rem;
-  margin-bottom: 0.5rem;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
 }
 
-.pageHeader p {
-  color: #4b5563;
+.pageDescription {
+  color: var(--text-secondary);
+  max-width: 58ch;
 }
 
 .pageBody {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2.25rem;
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 1280px) {
+  .appShell {
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+  }
+}
+
+@media (max-width: 1200px) {
+  .appShell {
+    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+  }
+
+  .contentArea {
+    padding: clamp(2.25rem, 4vw, 3rem);
+  }
 }
 
 @media (max-width: 960px) {
   .appShell {
     grid-template-columns: 1fr;
+    gap: 1.75rem;
   }
 
   .sidebar {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    position: relative;
+    top: auto;
+    z-index: 10;
+    padding: 1.85rem 1.6rem;
+    gap: 1.65rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: var(--shadow-sm);
   }
 
-  .sidebar ul {
+  .navList {
     flex-direction: row;
-    flex-wrap: wrap;
+    gap: 0.75rem;
+    overflow-x: auto;
+    padding: 0.5rem 0.75rem 0.75rem;
+    margin: 0;
+  }
+
+  .navLink {
+    flex: 0 0 auto;
+    min-width: max-content;
+    transform: none;
+  }
+
+  .navLinkActive {
+    transform: none;
+  }
+
+  .contentArea {
+    padding: 2.35rem 1.75rem 2.75rem;
+    border-radius: var(--radius-lg);
+  }
+
+  .pageHeader {
+    padding: 1.65rem 1.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar {
+    padding: 1.5rem 1.2rem;
+  }
+
+  .brand {
+    font-size: 1.6rem;
+  }
+
+  .contentArea {
+    padding: 2rem 1.25rem 2.5rem;
+  }
+
+  .pageHeader {
+    padding: 1.5rem 1.5rem;
+  }
+
+  .pageTitle {
+    font-size: 1.7rem;
   }
 }

--- a/frontend/src/styles/Login.module.css
+++ b/frontend/src/styles/Login.module.css
@@ -7,10 +7,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-  padding: 1.75rem;
+  background: var(--surface-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-xs);
+  padding: 1.9rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -19,13 +20,13 @@
 .card h3 {
   margin: 0;
   font-size: 1.25rem;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .card p {
   margin: 0;
   line-height: 1.5;
-  color: #334155;
+  color: var(--text-secondary);
 }
 
 .googleButton {
@@ -33,19 +34,20 @@
   align-items: center;
   gap: 0.75rem;
   justify-content: center;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 999px;
-  padding: 0.75rem 1.5rem;
+  background: var(--surface-card-strong);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-pill);
+  padding: 0.8rem 1.6rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-primary);
   cursor: pointer;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: box-shadow 0.25s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
 .googleButton:hover:not(:disabled) {
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
-  transform: translateY(-1px);
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.35);
+  transform: translateY(-2px);
 }
 
 .googleButton:disabled {
@@ -65,11 +67,14 @@
   color: #ef4444;
   font-weight: 600;
   cursor: pointer;
-  padding: 0.25rem 0;
+  padding: 0.35rem 0.25rem;
+  border-radius: 6px;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .signOutButton:hover:not(:disabled) {
-  text-decoration: underline;
+  background: rgba(248, 113, 113, 0.16);
+  transform: translateY(-1px);
 }
 
 .errorMessage {
@@ -81,20 +86,20 @@
   font-weight: 600;
   padding: 0.5rem 0.75rem;
   border-radius: 999px;
-  background: #f1f5f9;
-  color: #0f172a;
+  background: var(--surface-muted);
+  color: var(--text-primary);
   display: inline-flex;
   align-items: center;
 }
 
 .statusLabel[data-status='signed-in'] {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--feedback-success-bg);
+  color: var(--feedback-success-text);
 }
 
 .statusLabel[data-status='signed-out'] {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
 }
 
 .profile {
@@ -116,18 +121,18 @@
 
 .profileDetails dt {
   font-weight: 600;
-  color: #475569;
+  color: var(--text-secondary);
 }
 
 .profileDetails dd {
   margin: 0.25rem 0 0;
-  color: #0f172a;
+  color: var(--text-primary);
   word-break: break-all;
 }
 
 .emptyProfile {
   margin: 0;
-  color: #475569;
+  color: var(--text-secondary);
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/styles/MuscleGroups.module.css
+++ b/frontend/src/styles/MuscleGroups.module.css
@@ -1,52 +1,55 @@
 .formSection {
   margin-bottom: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.3);
+  padding: 2rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
 }
 
 .fieldGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .fieldGroup label {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--text-primary);
 }
 
 .fieldGroup input,
 .fieldGroup textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   font-family: inherit;
+  background: var(--surface-card-strong);
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .fieldGroup textarea {
   resize: vertical;
-  min-height: 120px;
+  min-height: 140px;
 }
 
 .fieldGroup input:focus,
 .fieldGroup textarea:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  border-color: var(--accent-500);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
 }
 
 .actions {
@@ -55,55 +58,60 @@
 }
 
 .actions button {
-  background: #2563eb;
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent-500), var(--accent-600));
+  color: var(--text-contrast);
   border: none;
-  border-radius: 999px;
-  padding: 0.75rem 1.75rem;
+  border-radius: var(--radius-pill);
+  padding: 0.85rem 1.85rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+  box-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.55);
 }
 
 .actions button:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .actions button:not(:disabled):hover {
-  background: #1d4ed8;
+  transform: translateY(-2px);
 }
 
 .actions button:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .success {
   margin: 0;
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--feedback-success-bg);
+  color: var(--feedback-success-text);
+  border: 1px solid var(--feedback-success-border);
+  padding: 0.85rem 1.2rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .error {
   margin: 0;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
+  padding: 0.85rem 1.2rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .card {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.5rem;
-  background: #f9fafb;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  background: var(--surface-card);
+  box-shadow: var(--shadow-xs);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .cardHeader {
@@ -115,18 +123,22 @@
 
 .cardHeader h3 {
   margin: 0;
-  font-size: 1.1rem;
-  color: #111827;
+  font-size: 1.15rem;
+  color: var(--text-primary);
 }
 
 .cardHeader time {
-  color: #6b7280;
-  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.16);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-pill);
 }
 
 .cardDescription {
   margin: 0;
-  color: #374151;
+  color: var(--text-secondary);
+  line-height: 1.55;
 }
 
 .cardActions {
@@ -135,31 +147,33 @@
 }
 
 .deleteButton {
-  border: 1px solid #fca5a5;
-  background: #fef2f2;
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  background: rgba(254, 226, 226, 0.4);
   color: #b91c1c;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1.35rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform 0.2s ease, box-shadow 0.25s ease, background 0.25s ease;
+  box-shadow: 0 12px 24px -16px rgba(248, 113, 113, 0.45);
 }
 
 .deleteButton:not(:disabled):hover {
-  background: #fee2e2;
+  background: rgba(254, 202, 202, 0.55);
 }
 
 .deleteButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0.5px);
 }
 
 .deleteButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 @media (max-width: 640px) {
   .formSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/styles/ResourceList.module.css
+++ b/frontend/src/styles/ResourceList.module.css
@@ -1,27 +1,47 @@
 .list {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .listItem {
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  background: var(--surface-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-soft);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-xs);
+  transition: transform 0.3s ease, box-shadow 0.35s ease;
+  overflow: hidden;
+}
+
+.listItem::after {
+  content: '';
+  position: absolute;
+  inset: -50% -25% auto;
+  height: 85%;
+  background: radial-gradient(90% 90% at 25% 25%, rgba(99, 102, 241, 0.14) 0%, transparent 70%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
 }
 
 .listItem:hover,
 .listItem:focus-within {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-sm);
+}
+
+.listItem:hover::after,
+.listItem:focus-within::after {
+  opacity: 1;
 }
 
 .emptyState {
-  padding: 2rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  padding: 2.25rem;
+  background: var(--feedback-warning-bg);
+  border: 1px solid var(--feedback-warning-border);
+  border-radius: var(--radius-lg);
+  color: var(--feedback-warning-text);
   text-align: center;
+  box-shadow: var(--shadow-xs);
 }

--- a/frontend/src/styles/Sessions.module.css
+++ b/frontend/src/styles/Sessions.module.css
@@ -1,45 +1,54 @@
 .error {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .cardHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .cardHeader span {
-  background: #7c3aed;
-  color: #ffffff;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.12));
+  color: var(--accent-600);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-pill);
   font-size: 0.85rem;
   font-weight: 600;
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  box-shadow: 0 6px 18px -12px rgba(99, 102, 241, 0.45);
 }
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.1rem;
+  margin-top: 1.25rem;
 }
 
 .metrics div {
-  background: #eef2ff;
-  border-radius: 10px;
-  padding: 0.75rem;
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .metrics dt {
   font-weight: 600;
-  color: #312e81;
+  color: var(--text-primary);
 }
 
 .metrics dd {
-  color: #4338ca;
+  color: var(--text-secondary);
+  margin-top: 0.35rem;
 }

--- a/frontend/src/styles/WorkoutClassForm.module.css
+++ b/frontend/src/styles/WorkoutClassForm.module.css
@@ -41,10 +41,11 @@
   flex-direction: column;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
-  border-radius: 12px;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  color: #92400e;
+  border-radius: var(--radius-md);
+  background: var(--feedback-warning-bg);
+  border: 1px solid var(--feedback-warning-border);
+  color: var(--feedback-warning-text);
+  box-shadow: var(--shadow-xs);
 }
 
 .prefillBanner strong {
@@ -61,19 +62,21 @@
 
 .clearPrefillButton {
   align-self: flex-start;
-  background: #ffffff;
-  border: 1px solid #f59e0b;
-  color: #b45309;
-  border-radius: 999px;
+  background: rgba(254, 243, 199, 0.5);
+  border: 1px solid rgba(251, 191, 36, 0.6);
+  color: var(--feedback-warning-text);
+  border-radius: var(--radius-pill);
   padding: 0.45rem 1.25rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 10px 22px -16px rgba(251, 191, 36, 0.5);
 }
 
 .clearPrefillButton:hover {
-  background: #fef08a;
-  color: #92400e;
+  background: rgba(253, 224, 71, 0.4);
+  color: #854d0e;
+  transform: translateY(-1px);
 }
 
 @media (min-width: 640px) {
@@ -98,25 +101,25 @@
 
 .fieldGroup label {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--text-primary);
 }
 
 .fieldGroup input,
 .fieldGroup select {
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.8rem 1rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  background-color: #ffffff;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  background-color: var(--surface-card-strong);
   font-family: inherit;
 }
 
 .fieldGroup input:focus,
 .fieldGroup select:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  border-color: var(--accent-500);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
 }
 
 .fieldGroup select:disabled {
@@ -132,10 +135,11 @@
 }
 
 .exerciseCard {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.5rem;
-  background: #f9fafb;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  background: var(--surface-card);
+  box-shadow: var(--shadow-xs);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -144,7 +148,7 @@
 .exerciseLegend {
   font-weight: 700;
   font-size: 1rem;
-  color: #111827;
+  color: var(--text-primary);
   padding: 0 0.25rem;
 }
 
@@ -188,14 +192,14 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
-  border: 1px dashed #c7d2fe;
-  border-radius: 10px;
-  background: #eef2ff;
+  border: 1px dashed rgba(129, 140, 248, 0.45);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
 }
 
 .setLabel {
   font-weight: 600;
-  color: #3730a3;
+  color: var(--accent-600);
 }
 
 .setActions {
@@ -212,105 +216,117 @@
 
 .primaryButton {
   align-self: flex-end;
-  background: #2563eb;
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent-500), var(--accent-600));
+  color: var(--text-contrast);
   border: none;
-  border-radius: 999px;
-  padding: 0.75rem 1.75rem;
+  border-radius: var(--radius-pill);
+  padding: 0.85rem 1.9rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+  box-shadow: 0 20px 40px -22px rgba(79, 70, 229, 0.6);
 }
 
 .primaryButton:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .primaryButton:not(:disabled):hover {
-  background: #1d4ed8;
+  transform: translateY(-2px);
 }
 
 .primaryButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .secondaryButton {
-  background: #e0e7ff;
-  color: #312e81;
-  border: none;
-  border-radius: 999px;
-  padding: 0.65rem 1.5rem;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-700);
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  border-radius: var(--radius-pill);
+  padding: 0.7rem 1.6rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -18px rgba(99, 102, 241, 0.35);
 }
 
 .secondaryButton:hover {
-  background: #c7d2fe;
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
 }
 
 .saveExerciseButton {
-  background: #ecfccb;
-  color: #3f6212;
-  border: 1px solid #bbf7d0;
-  border-radius: 999px;
-  padding: 0.55rem 1.5rem;
+  background: rgba(220, 252, 231, 0.7);
+  color: var(--feedback-success-text);
+  border: 1px solid var(--feedback-success-border);
+  border-radius: var(--radius-pill);
+  padding: 0.6rem 1.6rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 12px 22px -16px rgba(74, 222, 128, 0.35);
 }
 
 .saveExerciseButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .saveExerciseButton:not(:disabled):hover {
-  background: #d9f99d;
-  border-color: #bef264;
+  background: rgba(187, 247, 208, 0.65);
+  transform: translateY(-1px);
 }
 
 .editorLinkButton {
-  background: #eef2ff;
-  color: #312e81;
-  border: 1px solid #c7d2fe;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-700);
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1.35rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -18px rgba(99, 102, 241, 0.35);
 }
 
 .editorLinkButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorLinkButton:not(:disabled):hover {
-  background: #c7d2fe;
-  border-color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -20px rgba(99, 102, 241, 0.4);
 }
 
 .dangerButton {
-  background: #fef2f2;
+  background: rgba(254, 226, 226, 0.4);
   color: #b91c1c;
-  border: 1px solid #fecaca;
-  border-radius: 999px;
-  padding: 0.5rem 1.2rem;
+  border: 1px solid rgba(248, 113, 113, 0.6);
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1.3rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 22px -16px rgba(248, 113, 113, 0.45);
 }
 
 .dangerButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .dangerButton:not(:disabled):hover {
-  background: #fee2e2;
-  border-color: #fca5a5;
+  background: rgba(254, 202, 202, 0.55);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px -18px rgba(248, 113, 113, 0.5);
 }
 
 .removeButton {
@@ -320,8 +336,8 @@
   font-weight: 600;
   cursor: pointer;
   padding: 0.5rem 0.75rem;
-  border-radius: 6px;
-  transition: background 0.2s ease;
+  border-radius: 8px;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .removeButton:disabled {
@@ -331,6 +347,7 @@
 
 .removeButton:not(:disabled):hover {
   background: rgba(248, 113, 113, 0.15);
+  transform: translateY(-1px);
 }
 
 .formActions {
@@ -343,33 +360,36 @@
 
 .inlineError {
   margin: 0;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
   padding: 0.75rem 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .inlineSuccess {
   margin: 0;
-  background: #dcfce7;
-  color: #047857;
-  border: 1px solid #bbf7d0;
+  background: var(--feedback-success-bg);
+  color: var(--feedback-success-text);
+  border: 1px solid var(--feedback-success-border);
   padding: 0.75rem 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .supportMessage {
   margin: 0;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
+  background: var(--feedback-info-bg);
+  color: var(--feedback-info-text);
+  border: 1px solid var(--feedback-info-border);
   padding: 0.75rem 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .supportMessage a {
-  color: #1d4ed8;
+  color: var(--feedback-info-text);
   font-weight: 600;
   text-decoration: none;
 }
@@ -382,10 +402,12 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  padding: 1.5rem;
-  border: 1px solid #dbeafe;
-  border-radius: 12px;
-  background: #eff6ff;
+  padding: 1.75rem;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  border-radius: var(--radius-lg);
+  background: rgba(238, 242, 255, 0.6);
+  box-shadow: 0 18px 40px -26px rgba(79, 70, 229, 0.4);
+  backdrop-filter: blur(6px);
 }
 
 .exerciseEditorHeader {
@@ -402,22 +424,23 @@
 
 .exerciseEditorHeader p {
   margin: 0.25rem 0 0;
-  color: #1d4ed8;
+  color: var(--accent-600);
 }
 
 .editorCloseButton {
   background: transparent;
   border: none;
-  color: #1f2937;
+  color: var(--text-primary);
   font-weight: 600;
   cursor: pointer;
   padding: 0.35rem 0.75rem;
   border-radius: 8px;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .editorCloseButton:hover {
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(99, 102, 241, 0.12);
+  transform: translateY(-1px);
 }
 
 .exerciseEditorGrid {
@@ -443,47 +466,52 @@
 }
 
 .editorPrimaryButton {
-  background: #2563eb;
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent-500), var(--accent-600));
+  color: var(--text-contrast);
   border: none;
-  border-radius: 999px;
-  padding: 0.65rem 1.6rem;
+  border-radius: var(--radius-pill);
+  padding: 0.7rem 1.7rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+  box-shadow: 0 16px 36px -22px rgba(79, 70, 229, 0.55);
 }
 
 .editorPrimaryButton:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorPrimaryButton:not(:disabled):hover {
-  background: #1d4ed8;
+  transform: translateY(-2px);
 }
 
 .editorPrimaryButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .editorSecondaryButton {
-  background: #e0e7ff;
-  color: #312e81;
-  border: none;
-  border-radius: 999px;
-  padding: 0.6rem 1.4rem;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-700);
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  border-radius: var(--radius-pill);
+  padding: 0.65rem 1.5rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -18px rgba(99, 102, 241, 0.35);
 }
 
 .editorSecondaryButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .editorSecondaryButton:not(:disabled):hover {
-  background: #c7d2fe;
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/styles/WorkoutClassList.module.css
+++ b/frontend/src/styles/WorkoutClassList.module.css
@@ -8,6 +8,11 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  background: var(--surface-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-xs);
 }
 
 .cardHeader {
@@ -20,6 +25,7 @@
 .cardHeader h3 {
   margin: 0 0 0.5rem;
   font-size: 1.4rem;
+  color: var(--text-primary);
 }
 
 .metaList {
@@ -29,7 +35,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  color: #4b5563;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -38,7 +44,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 0.5rem;
-  color: #1f2937;
+  color: var(--text-primary);
 }
 
 .metrics span {
@@ -50,9 +56,10 @@
 .notes {
   margin: 0;
   padding: 1rem;
-  border-radius: 10px;
-  background: #ecfdf5;
-  color: #047857;
+  border-radius: var(--radius-sm);
+  background: var(--feedback-success-bg);
+  color: var(--feedback-success-text);
+  border: 1px solid var(--feedback-success-border);
 }
 
 .cardActions {
@@ -74,27 +81,29 @@
   align-items: flex-start;
   gap: 0.25rem;
   padding: 0.65rem 1.1rem;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
-  color: #1e293b;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-soft);
+  background: var(--surface-muted);
+  color: var(--text-primary);
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.25s ease, transform 0.2s ease;
+  box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.35);
 }
 
 .sessionTab:hover,
 .sessionTab:focus-visible {
-  background: #e0f2fe;
+  background: rgba(99, 102, 241, 0.12);
   outline: none;
+  transform: translateY(-1px);
 }
 
 .activeSessionTab {
-  background: #1d4ed8;
-  color: #ffffff;
-  border-color: #1d4ed8;
-  box-shadow: 0 12px 30px rgba(29, 78, 216, 0.22);
+  background: linear-gradient(135deg, var(--accent-500), var(--accent-600));
+  color: var(--text-contrast);
+  border-color: transparent;
+  box-shadow: 0 18px 40px -24px rgba(79, 70, 229, 0.55);
 }
 
 .sessionTabLabel {
@@ -114,35 +123,39 @@
 }
 
 .sessionInfo {
-  color: #1f2937;
+  color: var(--text-primary);
   font-weight: 600;
 }
 
 .emptyMessage {
   padding: 1.25rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  background: var(--feedback-warning-bg);
+  border: 1px solid var(--feedback-warning-border);
+  border-radius: var(--radius-md);
+  color: var(--feedback-warning-text);
+  box-shadow: var(--shadow-xs);
 }
 
 .duplicateButton {
-  border: 1px solid #2563eb;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-700);
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1.35rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -18px rgba(99, 102, 241, 0.35);
 }
 
 .duplicateButton:not(:disabled):hover {
-  background: #dbeafe;
+  background: rgba(99, 102, 241, 0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px -18px rgba(99, 102, 241, 0.4);
 }
 
 .duplicateButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .duplicateButton:disabled,
@@ -157,22 +170,25 @@
 }
 
 .deleteButton {
-  border: 1px solid #dc2626;
-  background: #fef2f2;
+  border: 1px solid rgba(248, 113, 113, 0.6);
+  background: rgba(254, 226, 226, 0.4);
   color: #b91c1c;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1.35rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.1s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -18px rgba(248, 113, 113, 0.45);
 }
 
 .deleteButton:not(:disabled):hover {
-  background: #fee2e2;
+  background: rgba(254, 202, 202, 0.55);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px -18px rgba(248, 113, 113, 0.5);
 }
 
 .deleteButton:not(:disabled):active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .exerciseGrid {
@@ -182,13 +198,14 @@
 }
 
 .exerciseCard {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f8fafc;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  background: var(--surface-muted);
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 .exerciseHeader {
@@ -201,26 +218,28 @@
 .exerciseHeader h4 {
   margin: 0;
   font-size: 1.1rem;
+  color: var(--text-primary);
 }
 
 .exerciseHeader span {
-  color: #4b5563;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
 .seriesCount {
-  background: #dbeafe;
-  color: #1d4ed8;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.18);
+  color: var(--accent-700);
+  padding: 0.25rem 0.8rem;
+  border-radius: var(--radius-pill);
   font-weight: 600;
   font-size: 0.85rem;
 }
 
 .exerciseNotes {
   margin: 0;
-  color: #374151;
+  color: var(--text-secondary);
   font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .setList {
@@ -237,19 +256,20 @@
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 0.5rem;
   align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-card-strong);
+  border: 1px solid var(--border-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .setOrder {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--text-primary);
 }
 
 .setMetric {
-  color: #2563eb;
+  color: var(--accent-600);
   font-weight: 600;
 }
 

--- a/frontend/src/styles/WorkoutHistoryByDate.module.css
+++ b/frontend/src/styles/WorkoutHistoryByDate.module.css
@@ -6,9 +6,10 @@
 
 .empty {
   padding: 2rem;
-  background: #fff7ed;
-  border: 1px solid #fed7aa;
-  border-radius: 12px;
-  color: #9a3412;
+  background: var(--feedback-warning-bg);
+  border: 1px solid var(--feedback-warning-border);
+  border-radius: var(--radius-lg);
+  color: var(--feedback-warning-text);
   text-align: center;
+  box-shadow: var(--shadow-xs);
 }

--- a/frontend/src/styles/Workouts.module.css
+++ b/frontend/src/styles/Workouts.module.css
@@ -1,25 +1,26 @@
 .modeSection {
   margin-bottom: 2rem;
-  padding: 1.5rem 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #f8fafc;
+  padding: 1.85rem 2rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.35rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .modeHeader h3 {
   margin: 0 0 0.5rem;
   font-size: 1.25rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .modeDescription {
   margin: 0;
-  color: #475569;
-  line-height: 1.5;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 .modeToggle {
@@ -30,46 +31,47 @@
 
 .modeButton {
   flex: 1 1 240px;
-  padding: 0.85rem 1.25rem;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
-  color: #1e293b;
+  padding: 0.95rem 1.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-soft);
+  background: var(--surface-card-strong);
+  color: var(--text-primary);
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.35);
+  transition: border-color 0.25s ease, box-shadow 0.3s ease, transform 0.25s ease;
+  box-shadow: var(--shadow-xs);
 }
 
 .modeButton:hover {
-  border-color: #818cf8;
-  box-shadow: 0 18px 35px -20px rgba(79, 70, 229, 0.35);
-  transform: translateY(-1px);
+  border-color: var(--accent-400);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-2px);
 }
 
 .modeButtonActive {
-  border-color: #4f46e5;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(79, 70, 229, 0.05));
-  color: #312e81;
+  border-color: var(--accent-600);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(59, 130, 246, 0.08));
+  color: var(--accent-700);
+  box-shadow: 0 20px 40px -24px rgba(99, 102, 241, 0.45);
 }
 
 .formSection {
   margin-bottom: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.3);
+  padding: 2rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
+  box-shadow: var(--shadow-sm);
 }
 
 .historySection,
 .historyPreview {
   margin-top: 2rem;
-  padding: 1.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.2);
+  padding: 2rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
+  box-shadow: var(--shadow-xs);
 }
 
 .historyHeader {
@@ -80,12 +82,12 @@
   margin: 0 0 0.5rem;
   font-size: 1.2rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .historyHeader p {
   margin: 0;
-  color: #475569;
+  color: var(--text-secondary);
   line-height: 1.6;
 }
 
@@ -98,7 +100,7 @@
 
 .selectLabel {
   font-weight: 600;
-  color: #1e293b;
+  color: var(--text-primary);
 }
 
 .selectRow {
@@ -111,36 +113,37 @@
 .selectControl {
   flex: 1 1 260px;
   min-width: 220px;
-  padding: 0.75rem 1rem;
-  border: 1px solid #cbd5f5;
-  border-radius: 12px;
-  background: #f8fafc;
-  color: #1f2937;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+  color: var(--text-primary);
   font-size: 0.95rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
 }
 
 .selectControl:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  border-color: var(--accent-500);
+  background: var(--surface-card-strong);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
 }
 
 .selectAction {
-  padding: 0.75rem 1.5rem;
-  border-radius: 12px;
+  padding: 0.85rem 1.6rem;
+  border-radius: var(--radius-md);
   border: none;
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent-500), var(--accent-600));
+  color: var(--text-contrast);
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 12px 25px -18px rgba(79, 70, 229, 0.7);
+  transition: transform 0.2s ease, box-shadow 0.25s ease;
+  box-shadow: 0 16px 32px -20px rgba(79, 70, 229, 0.65);
 }
 
 .selectAction:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px -18px rgba(79, 70, 229, 0.75);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px -18px rgba(79, 70, 229, 0.7);
 }
 
 .selectAction:disabled {
@@ -151,25 +154,27 @@
 
 .success {
   margin-top: 1rem;
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+  background: var(--feedback-success-bg);
+  color: var(--feedback-success-text);
+  border: 1px solid var(--feedback-success-border);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .error {
   margin-top: 1rem;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--feedback-error-bg);
+  color: var(--feedback-error-text);
+  border: 1px solid var(--feedback-error-border);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 @media (max-width: 640px) {
   .modeSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .modeToggle {
@@ -177,12 +182,12 @@
   }
 
   .formSection {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .historySection,
   .historyPreview {
-    padding: 1.25rem;
+    padding: 1.5rem;
   }
 
   .selectRow {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,25 +1,103 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f5f5f5;
-  color: #1f1f1f;
+  font-feature-settings: 'liga', 'kern';
+  --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --gradient-background: radial-gradient(
+      140% 140% at 50% 0%,
+      rgba(99, 102, 241, 0.32) 0%,
+      rgba(56, 189, 248, 0.12) 28%,
+      rgba(15, 23, 42, 0) 65%
+    ),
+    linear-gradient(180deg, #020617 0%, #0b1220 38%, #111b2f 100%);
+  --surface-sidebar: rgba(12, 18, 32, 0.7);
+  --surface-sidebar-border: rgba(148, 163, 184, 0.18);
+  --surface-content: linear-gradient(160deg, rgba(244, 246, 255, 0.94) 0%, rgba(232, 239, 254, 0.82) 100%);
+  --surface-card: rgba(255, 255, 255, 0.86);
+  --surface-card-strong: #ffffff;
+  --surface-muted: rgba(241, 245, 249, 0.78);
+  --surface-overlay: rgba(15, 23, 42, 0.08);
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+  --text-contrast: #f8fafc;
+  --accent-200: #c7d2fe;
+  --accent-300: #a5b4fc;
+  --accent-400: #818cf8;
+  --accent-500: #6366f1;
+  --accent-600: #4f46e5;
+  --accent-700: #4338ca;
+  --success-500: #16a34a;
+  --danger-500: #dc2626;
+  --info-500: #2563eb;
+  --warning-500: #d97706;
+  --border-soft: rgba(148, 163, 184, 0.22);
+  --border-glass: rgba(148, 163, 184, 0.18);
+  --border-strong: rgba(148, 163, 184, 0.32);
+  --shadow-xs: 0 12px 32px -18px rgba(15, 23, 42, 0.42);
+  --shadow-sm: 0 20px 55px -30px rgba(15, 23, 42, 0.5);
+  --shadow-md: 0 30px 75px -32px rgba(15, 23, 42, 0.55);
+  --shadow-lg: 0 48px 110px -46px rgba(15, 23, 42, 0.65);
+  --radius-sm: 12px;
+  --radius-md: 18px;
+  --radius-lg: 24px;
+  --radius-xl: 32px;
+  --radius-pill: 999px;
+  --blur-strong: 28px;
+  --feedback-error-bg: rgba(254, 226, 226, 0.85);
+  --feedback-error-border: rgba(248, 113, 113, 0.7);
+  --feedback-error-text: #7f1d1d;
+  --feedback-success-bg: rgba(220, 252, 231, 0.85);
+  --feedback-success-border: rgba(134, 239, 172, 0.7);
+  --feedback-success-text: #166534;
+  --feedback-warning-bg: rgba(254, 243, 199, 0.85);
+  --feedback-warning-border: rgba(251, 191, 36, 0.65);
+  --feedback-warning-text: #92400e;
+  --feedback-info-bg: rgba(219, 234, 254, 0.82);
+  --feedback-info-border: rgba(96, 165, 250, 0.65);
+  --feedback-info-text: #1d4ed8;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 body {
-  background-color: #f5f5f5;
+  font-family: var(--font-family-sans);
+  background: var(--gradient-background);
+  background-attachment: fixed;
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 main {
   min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+a:hover {
+  opacity: 0.9;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+::selection {
+  background: rgba(99, 102, 241, 0.2);
+  color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary
- refresh the global palette with lighter gradients, glass borders, and larger radius tokens for a sleeker baseline
- redesign the app shell with a sticky glass sidebar, animated navigation states, and a centered content column
- soften content surfaces and headers to emphasize the new airy layout treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3eeaf10c0833091abded68cc36ebe