### PR TITLE
Revamp dashboard styling and polish home cards

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useState, type ReactNode } from 'react';
 import styles from '@/styles/Layout.module.css';
 
@@ -23,6 +24,7 @@ const navLinks: Array<{ href: string; label: string }> = [
 
 export default function Layout({ title, description, children }: LayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const pathname = usePathname();
 
   return (
     <div
@@ -64,11 +66,23 @@ export default function Layout({ title, description, children }: LayoutProps) {
           aria-hidden={!isSidebarOpen}
         >
           <ul>
-            {navLinks.map((link) => (
-              <li key={link.href}>
-                <Link href={link.href}>{link.label}</Link>
-              </li>
-            ))}
+            {navLinks.map((link) => {
+              const isActive =
+                pathname === link.href ||
+                (link.href !== '/' && pathname.startsWith(`${link.href}/`));
+
+              return (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className={isActive ? styles.activeLink : undefined}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </nav>
       </aside>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -5,26 +5,35 @@ import Link from 'next/link';
 import Layout from '@/components/Layout';
 import styles from '@/styles/Home.module.css';
 
-const cards: ReadonlyArray<{ href: string; title: string; description: string }> = [
+const cards: ReadonlyArray<{
+  href: string;
+  title: string;
+  description: string;
+  icon: string;
+}> = [
   {
     href: '/exercise-classes',
     title: 'Aulas',
-    description: 'Visualize todas as aulas cadastradas para o aluno atual.'
+    description: 'Visualize todas as aulas cadastradas para o aluno atual.',
+    icon: '🎓'
   },
   {
     href: '/workouts',
     title: 'Treinos',
-    description: 'Confira a estrutura completa dos treinos e suas sessões.'
+    description: 'Confira a estrutura completa dos treinos e suas sessões.',
+    icon: '💪'
   },
   {
     href: '/exercises',
     title: 'Exercícios',
-    description: 'Veja os exercícios disponíveis e detalhes de execução.'
+    description: 'Veja os exercícios disponíveis e detalhes de execução.',
+    icon: '🏋️'
   },
   {
     href: '/sessions',
     title: 'Sessões',
-    description: 'Acompanhe as sessões agendadas em cada aula.'
+    description: 'Acompanhe as sessões agendadas em cada aula.',
+    icon: '🗓️'
   }
 ];
 
@@ -37,8 +46,31 @@ export default function HomePage() {
       <div className={styles.grid}>
         {cards.map((card) => (
           <Link key={card.href} href={card.href} className={styles.card}>
-            <h3>{card.title}</h3>
+            <div className={styles.cardHeader}>
+              <span className={styles.cardIcon} aria-hidden="true">
+                {card.icon}
+              </span>
+              <h3>{card.title}</h3>
+            </div>
             <p>{card.description}</p>
+            <span className={styles.cardCta}>
+              Acessar módulo
+              <svg
+                className={styles.cardCtaIcon}
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M7.5 4.5L12.5 9.5L7.5 14.5"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
           </Link>
         ))}
       </div>

--- a/frontend/src/styles/Home.module.css
+++ b/frontend/src/styles/Home.module.css
@@ -1,31 +1,108 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .card {
-  background: #ffffff;
-  padding: 1.75rem;
-  border-radius: 12px;
-  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.25rem;
+  padding: clamp(2rem, 4vw, 2.75rem);
+  border-radius: 32px;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(224, 242, 254, 0.65));
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(10px);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -35% auto auto -25%;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.25), transparent 60%);
+  opacity: 0.7;
+  z-index: -1;
+  transition: transform 0.4s ease;
 }
 
 .card h3 {
-  font-size: 1.3rem;
-  color: #111827;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
 }
 
 .card p {
-  color: #4b5563;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.cardIcon {
+  font-size: 2rem;
+  filter: drop-shadow(0 10px 20px rgba(37, 99, 235, 0.35));
+}
+
+.cardCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: auto;
+  font-weight: 600;
+  color: var(--color-primary);
+  letter-spacing: 0.01em;
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.cardCtaIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+  transition: transform 0.3s ease;
 }
 
 .card:hover,
 .card:focus {
-  transform: translateY(-4px);
-  box-shadow: 0 25px 50px rgba(30, 41, 59, 0.12);
+  transform: translateY(-8px);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.18);
+}
+
+.card:hover::before,
+.card:focus::before {
+  transform: translate(25px, -15px) scale(1.05);
+}
+
+.card:hover .cardCta,
+.card:focus .cardCta {
+  color: #1d4ed8;
+  transform: translateX(6px);
+}
+
+.card:hover .cardCtaIcon,
+.card:focus .cardCtaIcon {
+  transform: translateX(4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .card::before,
+  .cardCta,
+  .cardCtaIcon {
+    transition: none;
+  }
+
+  .card:hover,
+  .card:focus {
+    transform: none;
+    box-shadow: var(--shadow-elevated);
+  }
 }

--- a/frontend/src/styles/Layout.module.css
+++ b/frontend/src/styles/Layout.module.css
@@ -1,65 +1,81 @@
 .appShell {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: clamp(240px, 22vw, 300px) minmax(0, 1fr);
   min-height: 100vh;
   transition: grid-template-columns 0.3s ease;
   position: relative;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .appShellCollapsed {
-  grid-template-columns: 0px 1fr;
+  grid-template-columns: 0px minmax(0, 1fr);
 }
 
 .sidebar {
-  background: linear-gradient(135deg, #111827, #1f2937);
-  color: #f9fafb;
-  padding: 5.5rem 1.5rem 2rem;
+  position: relative;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(37, 99, 235, 0.9));
+  color: #f8fafc;
+  padding: 5rem clamp(1.25rem, 2.5vw, 2rem) 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  transition: padding 0.3s ease;
-  position: relative;
-  overflow: visible;
+  gap: 2.5rem;
+  border-radius: 32px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.35), transparent 65%),
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.25), transparent 55%);
+  opacity: 0.8;
+  z-index: -1;
 }
 
 .brand {
-  font-size: 1.5rem;
-  font-weight: 600;
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
 }
 
 .toggleButton {
   align-self: flex-start;
-  background: #0f172a;
-  border: none;
+  background: linear-gradient(135deg, #ffffff, rgba(224, 242, 254, 0.85));
+  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 50%;
-  color: #ffffff;
   cursor: pointer;
   padding: 0;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   position: absolute;
   top: 2rem;
   left: 2rem;
-  width: 3.5rem;
-  height: 3.5rem;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.35);
+  width: 3.25rem;
+  height: 3.25rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
   z-index: 3;
 }
 
 .toggleButton:hover,
 .toggleButton:focus {
-  transform: scale(1.05);
-  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.45);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.3);
 }
 
 .toggleButtonOpen {
-  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.28);
 }
 
 .toggleButtonClosed {
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
 }
 
 .srOnly {
@@ -94,6 +110,10 @@
   gap: 0;
   padding: 0;
   width: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+  overflow: visible;
 }
 
 .sidebarCollapsed nav {
@@ -104,22 +124,60 @@
   display: none;
 }
 
+.sidebarCollapsed::before {
+  display: none;
+}
 
 .sidebar ul {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+
+.sidebar li {
+  display: flex;
 }
 
 .sidebar a {
-  color: #e5e7eb;
+  color: rgba(226, 232, 240, 0.88);
   font-weight: 500;
+  padding: 0.75rem 1.1rem;
+  border-radius: 999px;
+  transition: background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sidebar a::after {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background 0.3s ease, transform 0.3s ease;
 }
 
 .sidebar a:hover,
 .sidebar a:focus {
   color: #ffffff;
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.activeLink {
+  background: linear-gradient(135deg, #ffffff, rgba(224, 242, 254, 0.9));
+  color: #0f172a;
+  font-weight: 600;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.26);
+}
+
+.activeLink::after {
+  background: #2563eb;
+  transform: scale(1.4);
 }
 
 .navHidden {
@@ -127,47 +185,99 @@
 }
 
 .contentArea {
-  padding: 3rem 4rem;
-  background: #f5f7fb;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 5rem);
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
 }
 
 .contentAreaCollapsed {
-  padding-top: 5rem;
-  padding-left: 7rem;
+  padding-top: clamp(4rem, 8vw, 6rem);
+  padding-left: clamp(4rem, 9vw, 7rem);
 }
 
 .pageHeader {
-  margin-bottom: 2rem;
+  background: var(--color-surface);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.pageHeader::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -40% auto;
+  width: 160px;
+  height: 160px;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.2), transparent 65%);
+  z-index: -1;
 }
 
 .pageHeader h2 {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  letter-spacing: -0.015em;
 }
 
 .pageHeader p {
-  color: #4b5563;
+  color: var(--color-text-muted);
+  max-width: 52ch;
 }
 
 .pageBody {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
+  background: var(--color-surface-strong);
+  border-radius: 34px;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(8px);
+}
+
+@media (max-width: 1200px) {
+  .appShell {
+    grid-template-columns: clamp(220px, 30vw, 260px) minmax(0, 1fr);
+  }
 }
 
 @media (max-width: 960px) {
   .appShell {
     grid-template-columns: 1fr;
+    padding: 1.5rem;
   }
 
   .sidebar {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: stretch;
+    position: relative;
   }
 
-  .sidebar ul {
-    flex-direction: row;
-    flex-wrap: wrap;
+  .contentArea,
+  .contentAreaCollapsed {
+    padding: 2.5rem 1rem 3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .pageBody {
+    padding: 1.5rem;
+    border-radius: 24px;
+  }
+
+  .pageHeader {
+    border-radius: 22px;
+  }
+
+  .toggleButton {
+    top: 1.5rem;
+    left: 1.5rem;
   }
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,13 +1,17 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f5f5f5;
-  color: #1f1f1f;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
+  --color-background: #f3f6fc;
+  --color-background-alt: #eef2ff;
+  --color-surface: rgba(255, 255, 255, 0.86);
+  --color-surface-strong: rgba(255, 255, 255, 0.95);
+  --color-border: rgba(148, 163, 184, 0.22);
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-primary: #2563eb;
+  --shadow-elevated: 0 24px 60px rgba(15, 23, 42, 0.12);
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 * {
@@ -17,7 +21,25 @@ a {
 }
 
 body {
-  background-color: #f5f5f5;
+  min-height: 100vh;
+  background: radial-gradient(circle at 0% 0%, rgba(148, 163, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(2, 132, 199, 0.28), transparent 45%),
+    linear-gradient(180deg, rgba(236, 240, 255, 0.8), rgba(226, 232, 240, 0.9));
+  background-color: var(--color-background);
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'ss02' 1, 'ss03' 1;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
 }
 
 main {


### PR DESCRIPTION
## Summary
- refresh global design tokens and gradients for a more polished visual baseline
- restyle the layout shell with an elevated sidebar, active navigation states, and refined content containers
- enhance the home module cards with iconography, animated call-to-action, and improved hover feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4157883c48330aed35048e86a8595