### PR TITLE
Enable editing of saved workouts from history

### DIFF
--- a/frontend/src/components/workouts/WorkoutClassList.tsx
+++ b/frontend/src/components/workouts/WorkoutClassList.tsx
@@ -9,6 +9,7 @@ interface WorkoutClassListProps {
   classes: WorkoutClass[];
   emptyLabel: string;
   onDuplicate?: (workout: WorkoutClass) => void;
+  onEdit?: (workout: WorkoutClass, sessionId?: string | null) => void;
   onDelete?: (workout: WorkoutClass) => void;
   deletingIds?: ReadonlySet<string>;
 }
@@ -48,6 +49,7 @@ const sessionCountLabel = (count: number): string =>
 interface WorkoutCardProps {
   workout: WorkoutClass;
   onDuplicate?: (workout: WorkoutClass) => void;
+  onEdit?: (workout: WorkoutClass, sessionId?: string | null) => void;
   onDelete?: (workout: WorkoutClass) => void;
   deletingIds?: ReadonlySet<string>;
 }
@@ -55,7 +57,7 @@ interface WorkoutCardProps {
 const getSessionDateLabel = (session?: WorkoutSession): string =>
   formatDate(session?.scheduledFor) ?? 'Sem data';
 
-function WorkoutCard({ workout, onDuplicate, onDelete, deletingIds }: WorkoutCardProps) {
+function WorkoutCard({ workout, onDuplicate, onEdit, onDelete, deletingIds }: WorkoutCardProps) {
   const sessions = useMemo(() => workout.sessions ?? [], [workout.sessions]);
   const [activeSessionId, setActiveSessionId] = useState<string>(() => sessions[0]?.id ?? '');
 
@@ -100,6 +102,24 @@ function WorkoutCard({ workout, onDuplicate, onDelete, deletingIds }: WorkoutCar
     });
   };
 
+  const handleEditClick = () => {
+    if (!onEdit || !activeSession) {
+      return;
+    }
+
+    onEdit(
+      {
+        ...workout,
+        scheduledFor: activeSession.scheduledFor,
+        notes: activeSession.notes ?? workout.notes,
+        exercises: activeSession.exercises,
+        exerciseCount: activeSession.exerciseCount,
+        totalSets: activeSession.totalSets
+      },
+      activeSession.id
+    );
+  };
+
   return (
     <article className={styles.card}>
       <header className={styles.cardHeader}>
@@ -123,8 +143,18 @@ function WorkoutCard({ workout, onDuplicate, onDelete, deletingIds }: WorkoutCar
         ) : null}
       </header>
 
-      {onDuplicate || onDelete ? (
+      {onDuplicate || onDelete || onEdit ? (
         <div className={styles.cardActions}>
+          {onEdit ? (
+            <button
+              type="button"
+              className={styles.editButton}
+              onClick={handleEditClick}
+              disabled={isDeleting || !activeSession}
+            >
+              Editar treino
+            </button>
+          ) : null}
           {onDelete ? (
             <button
               type="button"
@@ -223,6 +253,7 @@ export default function WorkoutClassList({
   classes,
   emptyLabel,
   onDuplicate,
+  onEdit,
   onDelete,
   deletingIds
 }: WorkoutClassListProps) {
@@ -237,6 +268,7 @@ export default function WorkoutClassList({
           key={workout.id}
           workout={workout}
           onDuplicate={onDuplicate}
+          onEdit={onEdit}
           onDelete={onDelete}
           deletingIds={deletingIds}
         />

--- a/frontend/src/components/workouts/WorkoutHistoryByDate.tsx
+++ b/frontend/src/components/workouts/WorkoutHistoryByDate.tsx
@@ -8,6 +8,7 @@ interface WorkoutHistoryByDateProps {
   classes: WorkoutClass[];
   emptyLabel: string;
   onDuplicate?: (workout: WorkoutClass) => void;
+  onEdit?: (workout: WorkoutClass, sessionId?: string | null) => void;
   onDelete?: (workout: WorkoutClass) => void;
   deletingIds?: ReadonlySet<string>;
 }
@@ -16,6 +17,7 @@ export default function WorkoutHistoryByDate({
   classes,
   emptyLabel,
   onDuplicate,
+  onEdit,
   onDelete,
   deletingIds
 }: WorkoutHistoryByDateProps) {
@@ -29,6 +31,7 @@ export default function WorkoutHistoryByDate({
         classes={classes}
         emptyLabel={emptyLabel}
         onDuplicate={onDuplicate}
+        onEdit={onEdit}
         onDelete={onDelete}
         deletingIds={deletingIds}
       />

--- a/frontend/src/components/workouts/types.ts
+++ b/frontend/src/components/workouts/types.ts
@@ -15,6 +15,7 @@ export interface WorkoutExerciseDraft {
 
 export interface WorkoutClassFormState {
   workoutId: string | null;
+  sessionId: string | null;
   name: string;
   focus: string;
   scheduledFor: string;

--- a/frontend/src/styles/WorkoutClassList.module.css
+++ b/frontend/src/styles/WorkoutClassList.module.css
@@ -137,6 +137,25 @@
   transition: background 0.2s ease, transform 0.1s ease;
 }
 
+.editButton {
+  border: 1px solid #6366f1;
+  background: #eef2ff;
+  color: #4338ca;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.editButton:not(:disabled):hover {
+  background: #e0e7ff;
+}
+
+.editButton:not(:disabled):active {
+  transform: translateY(1px);
+}
+
 .duplicateButton:not(:disabled):hover {
   background: #dbeafe;
 }
@@ -146,12 +165,14 @@
 }
 
 .duplicateButton:disabled,
+.editButton:disabled,
 .deleteButton:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
 .duplicateButton:disabled:active,
+.editButton:disabled:active,
 .deleteButton:disabled:active {
   transform: none;
 }


### PR DESCRIPTION
## Summary
- add an edit action to each workout card so saved sessions can be loaded for changes
- extend the workout form and API client to support updating existing sessions
- refresh UI messaging/styles to distinguish between new entries and edits

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e555c5ce388330926afe77668d9ce8